### PR TITLE
add simple parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
     "test:watch": "jest --watchAll"
   },
   "devDependencies": {

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -36,4 +36,18 @@ describe("parseProgram()", () => {
       right: { type: "number node", value: 9 },
     });
   });
+
+  it("parse a single identifier expression", () => {
+    const input = "x";
+    const lexer = new Lexer(input);
+    const parser = new Parser(lexer);
+
+    const node = parser.parseProgram();
+    expect(node.statements.length).toBe(1);
+
+    expect(node.statements[0]).toEqual({
+      type: "expression statement",
+      expression: { type: "identifier", value: "x" },
+    });
+  });
 });

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -76,5 +76,63 @@ describe("parseProgram()", () => {
         expression: { type: "number node", value: 5 },
       });
     });
+
+    it("parse negative number literal expression", () => {
+      const input = "-42";
+      const lexer = new Lexer(input);
+      const parser = new Parser(lexer);
+
+      const node = parser.parseProgram();
+      expect(node.statements.length).toBe(1);
+
+      expect(node.statements[0]).toEqual({
+        type: "expression statement",
+        expression: {
+          type: "prefix expression",
+          prefix: "-",
+          expression: { type: "number node", value: 42 },
+        },
+      });
+    });
+
+    it("parse negative number literal expression", () => {
+      const input = "+42";
+      const lexer = new Lexer(input);
+      const parser = new Parser(lexer);
+
+      const node = parser.parseProgram();
+      expect(node.statements.length).toBe(1);
+
+      expect(node.statements[0]).toEqual({
+        type: "expression statement",
+        expression: {
+          type: "prefix expression",
+          prefix: "+",
+          expression: { type: "number node", value: 42 },
+        },
+      });
+    });
+
+    it("parse doubly negative number literal expression", () => {
+      const input = "--42";
+      const lexer = new Lexer(input);
+      const parser = new Parser(lexer);
+
+      const node = parser.parseProgram();
+      expect(node.statements.length).toBe(1);
+
+      expect(node.statements[0]).toEqual({
+        type: "expression statement",
+        expression: {
+          type: "prefix expression",
+          prefix: "-",
+          expression: {
+            type: "prefix expression",
+            prefix: "-",
+            expression: { type: "number node", value: 42 },
+          },
+        },
+      });
+    });
   });
 });

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -12,9 +12,12 @@ describe("parseProgram()", () => {
       expect(node.statements.length).toBe(1);
 
       expect(node.statements[0]).toEqual({
-        type: "assignment",
-        left: { type: "identifier", value: "x" },
-        right: { type: "number node", value: 42 },
+        type: "expression statement",
+        expression: {
+          type: "assignment",
+          left: { type: "identifier", value: "x" },
+          right: { type: "number node", value: 42 },
+        },
       });
     });
 
@@ -27,14 +30,20 @@ describe("parseProgram()", () => {
       expect(node.statements.length).toBe(2);
 
       expect(node.statements[0]).toEqual({
-        type: "assignment",
-        left: { type: "identifier", value: "x" },
-        right: { type: "number node", value: 42 },
+        type: "expression statement",
+        expression: {
+          type: "assignment",
+          left: { type: "identifier", value: "x" },
+          right: { type: "number node", value: 42 },
+        },
       });
       expect(node.statements[1]).toEqual({
-        type: "assignment",
-        left: { type: "identifier", value: "한" },
-        right: { type: "number node", value: 9 },
+        type: "expression statement",
+        expression: {
+          type: "assignment",
+          left: { type: "identifier", value: "한" },
+          right: { type: "number node", value: 9 },
+        },
       });
     });
   });

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -1,138 +1,159 @@
 import Lexer from "../lexer";
 import Parser from "./";
+import type { Program } from "./syntax-tree";
 
 describe("parseProgram()", () => {
+  const testParsing = ({ input, expected }: { input: string, expected: Program }) => {
+    const lexer = new Lexer(input);
+    const parser = new Parser(lexer);
+
+    const node = parser.parseProgram();
+
+    expect(node).toEqual(expected);
+  };
+
   describe("assignment", () => {
-    it("should parse an assignment statement", () => {
-      const input = "x = 42"
-      const lexer = new Lexer(input);
-      const parser = new Parser(lexer);
-
-      const node = parser.parseProgram();
-      expect(node.statements.length).toBe(1);
-
-      expect(node.statements[0]).toEqual({
-        type: "expression statement",
-        expression: {
-          type: "assignment",
-          left: { type: "identifier", value: "x" },
-          right: { type: "number node", value: 42 },
+    const cases: { name: string, input: string, expected: Program }[] = [
+      {
+        name: "a single assignment statement",
+        input: "x = 42",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: {
+                type: "assignment",
+                left: { type: "identifier", value: "x" },
+                right: { type: "number node", value: 42 },
+              },
+            },
+          ],
         },
-      });
-    });
-
-    it("should parse more than one assignment statements", () => {
-      const input = "x = 42 한 = 9"
-      const lexer = new Lexer(input);
-      const parser = new Parser(lexer);
-
-      const node = parser.parseProgram();
-      expect(node.statements.length).toBe(2);
-
-      expect(node.statements[0]).toEqual({
-        type: "expression statement",
-        expression: {
-          type: "assignment",
-          left: { type: "identifier", value: "x" },
-          right: { type: "number node", value: 42 },
+      },
+      {
+        name: "multiple assignment statements",
+        input: "x = 42 한 = 9 _123 = 123",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: {
+                type: "assignment",
+                left: { type: "identifier", value: "x" },
+                right: { type: "number node", value: 42 },
+              },
+            },
+            {
+              type: "expression statement",
+              expression: {
+                type: "assignment",
+                left: { type: "identifier", value: "한" },
+                right: { type: "number node", value: 9 },
+              },
+            },
+            {
+              type: "expression statement",
+              expression: {
+                type: "assignment",
+                left: { type: "identifier", value: "_123" },
+                right: { type: "number node", value: 123 },
+              },
+            },
+          ],
         },
-      });
-      expect(node.statements[1]).toEqual({
-        type: "expression statement",
-        expression: {
-          type: "assignment",
-          left: { type: "identifier", value: "한" },
-          right: { type: "number node", value: 9 },
-        },
-      });
-    });
+      },
+    ];
+
+    it.each(cases)("parse $name", testParsing);
   });
 
-  describe("single expression", () => {
-    it("parse a single identifier expression", () => {
-      const input = "x";
-      const lexer = new Lexer(input);
-      const parser = new Parser(lexer);
-
-      const node = parser.parseProgram();
-      expect(node.statements.length).toBe(1);
-
-      expect(node.statements[0]).toEqual({
-        type: "expression statement",
-        expression: { type: "identifier", value: "x" },
-      });
-    });
-
-    it("parse a number literal expression", () => {
-      const input = "5";
-      const lexer = new Lexer(input);
-      const parser = new Parser(lexer);
-
-      const node = parser.parseProgram();
-      expect(node.statements.length).toBe(1);
-
-      expect(node.statements[0]).toEqual({
-        type: "expression statement",
-        expression: { type: "number node", value: 5 },
-      });
-    });
-
-    it("parse negative number literal expression", () => {
-      const input = "-42";
-      const lexer = new Lexer(input);
-      const parser = new Parser(lexer);
-
-      const node = parser.parseProgram();
-      expect(node.statements.length).toBe(1);
-
-      expect(node.statements[0]).toEqual({
-        type: "expression statement",
-        expression: {
-          type: "prefix expression",
-          prefix: "-",
-          expression: { type: "number node", value: 42 },
+  describe("simple expression", () => {
+    const cases: { name: string, input: string, expected: Program }[] = [
+      {
+        name: "an identifier",
+        input: "x",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: { type: "identifier", value: "x" },
+            },
+          ],
         },
-      });
-    });
-
-    it("parse negative number literal expression", () => {
-      const input = "+42";
-      const lexer = new Lexer(input);
-      const parser = new Parser(lexer);
-
-      const node = parser.parseProgram();
-      expect(node.statements.length).toBe(1);
-
-      expect(node.statements[0]).toEqual({
-        type: "expression statement",
-        expression: {
-          type: "prefix expression",
-          prefix: "+",
-          expression: { type: "number node", value: 42 },
+      },
+      {
+        name: "a number",
+        input: "123",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: { type: "number node", value: 123 },
+            },
+          ],
         },
-      });
-    });
-
-    it("parse doubly negative number literal expression", () => {
-      const input = "--42";
-      const lexer = new Lexer(input);
-      const parser = new Parser(lexer);
-
-      const node = parser.parseProgram();
-      expect(node.statements.length).toBe(1);
-
-      expect(node.statements[0]).toEqual({
-        type: "expression statement",
-        expression: {
-          type: "prefix expression",
-          prefix: "-",
-          expression: {
-            type: "prefix expression",
-            prefix: "-",
-            expression: { type: "number node", value: 42 },
-          },
+      },
+      {
+        name: "a negative number",
+        input: "-42",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: {
+                type: "prefix expression",
+                prefix: "-",
+                expression: { type: "number node", value: 42 },
+              },
+            },
+          ],
         },
-      });
-    });
+      },
+      {
+        name: "a doubly negative number",
+        input: "--42",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: {
+                type: "prefix expression",
+                prefix: "-",
+                expression: {
+                  type: "prefix expression",
+                  prefix: "-",
+                  expression: { type: "number node", value: 42 },
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: "a positive number",
+        input: "+42",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: {
+                type: "prefix expression",
+                prefix: "+",
+                expression: { type: "number node", value: 42 },
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    it.each(cases)("parse $name", testParsing);
   });
 });

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -2,52 +2,70 @@ import Lexer from "../lexer";
 import Parser from "./";
 
 describe("parseProgram()", () => {
-  it("should parse an assignment statement", () => {
-    const input = "x = 42"
-    const lexer = new Lexer(input);
-    const parser = new Parser(lexer);
+  describe("assignment", () => {
+    it("should parse an assignment statement", () => {
+      const input = "x = 42"
+      const lexer = new Lexer(input);
+      const parser = new Parser(lexer);
 
-    const node = parser.parseProgram();
-    expect(node.statements.length).toBe(1);
+      const node = parser.parseProgram();
+      expect(node.statements.length).toBe(1);
 
-    expect(node.statements[0]).toEqual({
-      type: "assignment",
-      left: { type: "identifier", value: "x" },
-      right: { type: "number node", value: 42 },
+      expect(node.statements[0]).toEqual({
+        type: "assignment",
+        left: { type: "identifier", value: "x" },
+        right: { type: "number node", value: 42 },
+      });
+    });
+
+    it("should parse more than one assignment statements", () => {
+      const input = "x = 42 한 = 9"
+      const lexer = new Lexer(input);
+      const parser = new Parser(lexer);
+
+      const node = parser.parseProgram();
+      expect(node.statements.length).toBe(2);
+
+      expect(node.statements[0]).toEqual({
+        type: "assignment",
+        left: { type: "identifier", value: "x" },
+        right: { type: "number node", value: 42 },
+      });
+      expect(node.statements[1]).toEqual({
+        type: "assignment",
+        left: { type: "identifier", value: "한" },
+        right: { type: "number node", value: 9 },
+      });
     });
   });
 
-  it("should parse more than one assignment statements", () => {
-    const input = "x = 42 한 = 9"
-    const lexer = new Lexer(input);
-    const parser = new Parser(lexer);
+  describe("single expression", () => {
+    it("parse a single identifier expression", () => {
+      const input = "x";
+      const lexer = new Lexer(input);
+      const parser = new Parser(lexer);
 
-    const node = parser.parseProgram();
-    expect(node.statements.length).toBe(2);
+      const node = parser.parseProgram();
+      expect(node.statements.length).toBe(1);
 
-    expect(node.statements[0]).toEqual({
-      type: "assignment",
-      left: { type: "identifier", value: "x" },
-      right: { type: "number node", value: 42 },
+      expect(node.statements[0]).toEqual({
+        type: "expression statement",
+        expression: { type: "identifier", value: "x" },
+      });
     });
-    expect(node.statements[1]).toEqual({
-      type: "assignment",
-      left: { type: "identifier", value: "한" },
-      right: { type: "number node", value: 9 },
-    });
-  });
 
-  it("parse a single identifier expression", () => {
-    const input = "x";
-    const lexer = new Lexer(input);
-    const parser = new Parser(lexer);
+    it("parse a number literal expression", () => {
+      const input = "5";
+      const lexer = new Lexer(input);
+      const parser = new Parser(lexer);
 
-    const node = parser.parseProgram();
-    expect(node.statements.length).toBe(1);
+      const node = parser.parseProgram();
+      expect(node.statements.length).toBe(1);
 
-    expect(node.statements[0]).toEqual({
-      type: "expression statement",
-      expression: { type: "identifier", value: "x" },
+      expect(node.statements[0]).toEqual({
+        type: "expression statement",
+        expression: { type: "number node", value: 5 },
+      });
     });
   });
 });

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -56,14 +56,14 @@ export default class Parser {
     return makeNumberNode(parsedNumber);
   }
 
-  private parseExpressionStatement(): ExpressionStatement {
+  private parseExpression(): Expression  {
     let token: TokenType;
 
     token = this.buffer.read();
     this.buffer.next(); // eat token before throwing
     if (token.type === "number literal") {
       const numberNode = this.parseNumberLiteral(token.value);
-      return makeExpressionStatement(numberNode);
+      return numberNode;
     }
     if (token.type !== "identifier") {
       throw new Error(`not identifier, but received ${token.type}`);
@@ -72,7 +72,7 @@ export default class Parser {
 
     token = this.buffer.read();
     if (token.type !== "operator" || token.value !== "=") {
-      return makeExpressionStatement(identifier);
+      return identifier;
     }
     this.buffer.next(); // eat token after branching
 
@@ -82,10 +82,15 @@ export default class Parser {
     if (token.type !== "number literal") {
       throw new Error(`not number literal, but received ${token.type}`);
     }
-    const expression = this.parseNumberLiteral(token.value);
-    const assignment = makeAssignment(identifier, expression);
 
-    return makeExpressionStatement(assignment);
+    const expression = this.parseNumberLiteral(token.value);
+    return makeAssignment(identifier, expression);
+  }
+
+  private parseExpressionStatement(): ExpressionStatement {
+    const expression = this.parseExpression();
+
+    return makeExpressionStatement(expression);
   }
 
   private parseStatement(): Statement {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -70,11 +70,7 @@ export default class Parser {
     if (token.type !== "number literal") {
       throw new Error(`not number literal, but received ${token.type}`);
     }
-    const numberParsed = Number(token.value);
-    if (Number.isNaN(numberParsed)) {
-      throw new Error(`received NaN`);
-    }
-    const expression = SyntaxTree.numberNode(numberParsed);
+    const expression = this.parseNumberLiteral(token.value);
 
     return SyntaxTree.assignment(identifier, expression);
   }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -71,8 +71,9 @@ export default class Parser {
       throw new Error(`not number literal, but received ${token.type}`);
     }
     const expression = this.parseNumberLiteral(token.value);
+    const assignment = SyntaxTree.assignment(identifier, expression);
 
-    return SyntaxTree.assignment(identifier, expression);
+    return SyntaxTree.expressionStatement(assignment);
   }
 
   parseProgram(): SyntaxTree.Program {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -44,7 +44,7 @@ export default class Parser {
     return SyntaxTree.numberNode(parsedNumber);
   }
 
-  private parseStatement(): SyntaxTree.Statement {
+  private parseExpressionStatement(): SyntaxTree.ExpressionStatement {
     let token: TokenType;
 
     token = this.buffer.read();
@@ -74,6 +74,10 @@ export default class Parser {
     const assignment = SyntaxTree.assignment(identifier, expression);
 
     return SyntaxTree.expressionStatement(assignment);
+  }
+
+  private parseStatement(): SyntaxTree.Statement {
+    return this.parseExpressionStatement();
   }
 
   parseProgram(): SyntaxTree.Program {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -4,6 +4,7 @@ import {
   makeAssignment,
   makeNumberNode,
   makeExpressionStatement,
+  makePrefixExpression,
 } from "./syntax-tree";
 import type {
   Program,
@@ -11,6 +12,7 @@ import type {
   NumberNode,
   ExpressionStatement,
   Expression,
+  PrefixExpression,
 } from "./syntax-tree";
 import Lexer from "../lexer";
 import type { TokenType } from "../lexer";
@@ -64,6 +66,15 @@ export default class Parser {
     if (token.type === "identifier") {
       const identifier = makeIdentifier(token.value);
       return identifier;
+    }
+    if (
+      token.type === "operator" &&
+      (token.value === "+" || token.value === "-")
+    ) {
+      const subExpression = this.parseExpression();
+      const prefix = token.value;
+      const expression = makePrefixExpression(prefix, subExpression);
+      return expression;
     }
 
     throw new Error(`bad token type ${token.type} for prefix expression`);

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -35,21 +35,21 @@ export default class Parser {
     let token: TokenType;
 
     token = this.buffer.read();
-    this.buffer.next();
+    this.buffer.next(); // eat token before throwing
     if (token.type !== "identifier") {
       throw new Error(`not identifier, but received ${token.type}`);
     }
     const identifier = SyntaxTree.identifier(token.value);
 
     token = this.buffer.read();
-    this.buffer.next();
     if (token.type !== "operator" || token.value !== "=") {
-      throw new Error(`not operator =, but received ${token.type}`);
+      return SyntaxTree.expressionStatement(identifier);
     }
+    this.buffer.next(); // eat token after branching
 
     // TODO: support more node type (currenly number literal supported)
     token = this.buffer.read();
-    this.buffer.next();
+    this.buffer.next(); // eat token before throwing
     if (token.type !== "number literal") {
       throw new Error(`not number literal, but received ${token.type}`);
     }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,9 +1,9 @@
 import {
-  program as makeProgram,
-  identifier as makeIdentifier,
-  assignment as makeAssignment,
-  numberNode,
-  expressionStatement,
+  makeProgram,
+  makeIdentifier,
+  makeAssignment,
+  makeNumberNode,
+  makeExpressionStatement,
 } from "./syntax-tree";
 import type {
   Program,
@@ -53,7 +53,7 @@ export default class Parser {
       throw new Error(`expected non-NaN number, but received '${literal}'`);
     }
 
-    return numberNode(parsedNumber);
+    return makeNumberNode(parsedNumber);
   }
 
   private parseExpressionStatement(): ExpressionStatement {
@@ -63,7 +63,7 @@ export default class Parser {
     this.buffer.next(); // eat token before throwing
     if (token.type === "number literal") {
       const numberNode = this.parseNumberLiteral(token.value);
-      return expressionStatement(numberNode);
+      return makeExpressionStatement(numberNode);
     }
     if (token.type !== "identifier") {
       throw new Error(`not identifier, but received ${token.type}`);
@@ -72,7 +72,7 @@ export default class Parser {
 
     token = this.buffer.read();
     if (token.type !== "operator" || token.value !== "=") {
-      return expressionStatement(identifier);
+      return makeExpressionStatement(identifier);
     }
     this.buffer.next(); // eat token after branching
 
@@ -85,7 +85,7 @@ export default class Parser {
     const expression = this.parseNumberLiteral(token.value);
     const assignment = makeAssignment(identifier, expression);
 
-    return expressionStatement(assignment);
+    return makeExpressionStatement(assignment);
   }
 
   private parseStatement(): Statement {

--- a/src/parser/syntax-tree/expression/index.ts
+++ b/src/parser/syntax-tree/expression/index.ts
@@ -1,4 +1,4 @@
-export type Expression = Identifier | NumberNode | Assignment;
+export type Expression = Identifier | NumberNode | PrefixExpression | Assignment;
 
 export interface Identifier {
   type: "identifier";
@@ -8,6 +8,12 @@ export interface Identifier {
 export interface NumberNode {
   type: "number node";
   value: number;
+}
+
+export interface PrefixExpression {
+  type: "prefix expression";
+  prefix: "+" | "-";
+  expression: Expression;
 }
 
 export interface Assignment {
@@ -26,6 +32,11 @@ export const makeNumberNode = (value: NumberNode["value"]): NumberNode => ({
   value,
 });
 
+export const makePrefixExpression = (prefix: PrefixExpression["prefix"], expression: PrefixExpression["expression"]): PrefixExpression => ({
+  type: "prefix expression",
+  prefix,
+  expression,
+});
 
 export const makeAssignment = (left: Assignment["left"], right: Assignment["right"]): Assignment => ({
   type: "assignment",

--- a/src/parser/syntax-tree/expression/index.ts
+++ b/src/parser/syntax-tree/expression/index.ts
@@ -1,0 +1,21 @@
+export type Expression = Identifier | NumberNode;
+
+export interface Identifier {
+  type: "identifier";
+  value: string;
+}
+
+export interface NumberNode {
+  type: "number node";
+  value: number;
+}
+
+export const identifier = (value: Identifier["value"]): Identifier => ({
+  type: "identifier",
+  value,
+});
+
+export const numberNode = (value: NumberNode["value"]): NumberNode => ({
+  type: "number node",
+  value,
+});

--- a/src/parser/syntax-tree/expression/index.ts
+++ b/src/parser/syntax-tree/expression/index.ts
@@ -1,4 +1,4 @@
-export type Expression = Identifier | NumberNode;
+export type Expression = Identifier | NumberNode | Assignment;
 
 export interface Identifier {
   type: "identifier";
@@ -10,6 +10,12 @@ export interface NumberNode {
   value: number;
 }
 
+export interface Assignment {
+  type: "assignment";
+  left: Identifier;
+  right: Expression;
+}
+
 export const identifier = (value: Identifier["value"]): Identifier => ({
   type: "identifier",
   value,
@@ -18,4 +24,11 @@ export const identifier = (value: Identifier["value"]): Identifier => ({
 export const numberNode = (value: NumberNode["value"]): NumberNode => ({
   type: "number node",
   value,
+});
+
+
+export const assignment = (left: Assignment["left"], right: Assignment["right"]): Assignment => ({
+  type: "assignment",
+  left,
+  right,
 });

--- a/src/parser/syntax-tree/expression/index.ts
+++ b/src/parser/syntax-tree/expression/index.ts
@@ -16,18 +16,18 @@ export interface Assignment {
   right: Expression;
 }
 
-export const identifier = (value: Identifier["value"]): Identifier => ({
+export const makeIdentifier = (value: Identifier["value"]): Identifier => ({
   type: "identifier",
   value,
 });
 
-export const numberNode = (value: NumberNode["value"]): NumberNode => ({
+export const makeNumberNode = (value: NumberNode["value"]): NumberNode => ({
   type: "number node",
   value,
 });
 
 
-export const assignment = (left: Assignment["left"], right: Assignment["right"]): Assignment => ({
+export const makeAssignment = (left: Assignment["left"], right: Assignment["right"]): Assignment => ({
   type: "assignment",
   left,
   right,

--- a/src/parser/syntax-tree/group/index.ts
+++ b/src/parser/syntax-tree/group/index.ts
@@ -1,0 +1,13 @@
+import type * as Statement from "../statement";
+
+export type Group = Program;
+
+export interface Program {
+  type: "program";
+  statements: Statement.Statement[];
+}
+
+export const program = (statements: Program["statements"] = []): Program => ({
+  type: "program",
+  statements,
+});

--- a/src/parser/syntax-tree/group/index.ts
+++ b/src/parser/syntax-tree/group/index.ts
@@ -7,7 +7,7 @@ export interface Program {
   statements: Statement.Statement[];
 }
 
-export const program = (statements: Program["statements"] = []): Program => ({
+export const makeProgram = (statements: Program["statements"] = []): Program => ({
   type: "program",
   statements,
 });

--- a/src/parser/syntax-tree/index.ts
+++ b/src/parser/syntax-tree/index.ts
@@ -1,45 +1,12 @@
-export type Node = Program | Identifier;
-export type Statement = Assignment;
-export type Expression = Identifier | NumberNode;
+import type { Group } from "./group";
+import type { Statement } from "./statement";
+import type { Expression } from "./expression";
 
-export interface Program {
-  type: "program";
-  statements: Statement[];
-}
+export type Node = Group | Statement | Expression;
 
-export interface Assignment {
-  type: "assignment";
-  left: Identifier;
-  right: Expression;
-}
-
-export interface Identifier {
-  type: "identifier";
-  value: string;
-}
-
-export interface NumberNode {
-  type: "number node";
-  value: number;
-}
-
-export const program = (statements: Statement[] = []): Program => ({
-  type: "program",
-  statements,
-});
-
-export const assignment = (left: Identifier, right: Expression): Assignment => ({
-  type: "assignment",
-  left,
-  right,
-});
-
-export const identifier = (value: string): Identifier => ({
-  type: "identifier",
-  value,
-});
-
-export const numberNode = (value: number): NumberNode => ({
-  type: "number node",
-  value,
-});
+export * from "./expression";
+export * from "./statement";
+export * from "./group";
+export type * from "./expression";
+export type * from "./statement";
+export type * from "./group";

--- a/src/parser/syntax-tree/statement/index.ts
+++ b/src/parser/syntax-tree/statement/index.ts
@@ -1,6 +1,6 @@
 import type * as Expression from "../expression";
 
-export type Statement = Assignment;
+export type Statement = Assignment | ExpressionStatement;
 
 /** An assignment statement where the assignment operator ('=') is used */
 export interface Assignment {

--- a/src/parser/syntax-tree/statement/index.ts
+++ b/src/parser/syntax-tree/statement/index.ts
@@ -1,25 +1,12 @@
 import type * as Expression from "../expression";
 
-export type Statement = Assignment | ExpressionStatement;
-
-/** An assignment statement where the assignment operator ('=') is used */
-export interface Assignment {
-  type: "assignment";
-  left: Expression.Identifier;
-  right: Expression.Expression;
-}
+export type Statement = ExpressionStatement;
 
 /** A wrapper type to treat a single expression as a statement. */
 export interface ExpressionStatement {
   type: "expression statement";
   expression: Expression.Expression;
 }
-
-export const assignment = (left: Assignment["left"], right: Assignment["right"]): Assignment => ({
-  type: "assignment",
-  left,
-  right,
-});
 
 export const expressionStatement = (expression: ExpressionStatement["expression"]): ExpressionStatement => ({
   type: "expression statement",

--- a/src/parser/syntax-tree/statement/index.ts
+++ b/src/parser/syntax-tree/statement/index.ts
@@ -1,0 +1,15 @@
+import type * as Expression from "../expression";
+
+export type Statement = Assignment;
+
+export interface Assignment {
+  type: "assignment";
+  left: Expression.Identifier;
+  right: Expression.Expression;
+}
+
+export const assignment = (left: Assignment["left"], right: Assignment["right"]): Assignment => ({
+  type: "assignment",
+  left,
+  right,
+});

--- a/src/parser/syntax-tree/statement/index.ts
+++ b/src/parser/syntax-tree/statement/index.ts
@@ -8,7 +8,7 @@ export interface ExpressionStatement {
   expression: Expression.Expression;
 }
 
-export const expressionStatement = (expression: ExpressionStatement["expression"]): ExpressionStatement => ({
+export const makeExpressionStatement = (expression: ExpressionStatement["expression"]): ExpressionStatement => ({
   type: "expression statement",
   expression,
 });

--- a/src/parser/syntax-tree/statement/index.ts
+++ b/src/parser/syntax-tree/statement/index.ts
@@ -2,6 +2,7 @@ import type * as Expression from "../expression";
 
 export type Statement = Assignment;
 
+/** An assignment statement where the assignment operator ('=') is used */
 export interface Assignment {
   type: "assignment";
   left: Expression.Identifier;

--- a/src/parser/syntax-tree/statement/index.ts
+++ b/src/parser/syntax-tree/statement/index.ts
@@ -8,8 +8,19 @@ export interface Assignment {
   right: Expression.Expression;
 }
 
+/** A wrapper type to treat a single expression as a statement. */
+export interface ExpressionStatement {
+  type: "expression statement";
+  expression: Expression.Expression;
+}
+
 export const assignment = (left: Assignment["left"], right: Assignment["right"]): Assignment => ({
   type: "assignment",
   left,
   right,
+});
+
+export const expressionStatement = (expression: ExpressionStatement["expression"]): ExpressionStatement => ({
+  type: "expression statement",
+  expression,
 });


### PR DESCRIPTION
features
- parse identifier and number literal (such as `42`, `+42`, `-42`, or `--42`)

refactoring
- organizing syntax tree types: divide syntax tree nodes into `Group`, `Statement`, and `Expression` types
- clarifying parsing logic: factor out prefix and infix parsing logic into private methods, and expression parsing logic as well
- extensible parser testing: factor out test cases and test functions into separate objects

typo
- append comma after `test` command in `package.json`