### PR TITLE
evaluate simple number expression

### DIFF
--- a/src/code-generator/index.test.ts
+++ b/src/code-generator/index.test.ts
@@ -1,3 +1,0 @@
-import CodeGenerator from "./";
-
-it.todo("");

--- a/src/code-generator/index.ts
+++ b/src/code-generator/index.ts
@@ -1,5 +1,0 @@
-export default class CodeGenerator {
-  generate(_syntaxTree: any) { // stub
-    return "codes";
-  }
-}

--- a/src/evaluator/index.test.ts
+++ b/src/evaluator/index.test.ts
@@ -1,0 +1,22 @@
+import Lexer from "../lexer";
+import Parser from "../parser";
+import Evaluator from "./";
+
+describe("evaluate()", () => {
+  const cases = [
+    { input: "5", expected: 5 },
+    { input: "-5", expected: -5 },
+    { input: "--5", expected: 5 },
+    { input: "+5", expected: 5 },
+  ];
+
+  it.each(cases)("evaluate $input", ({ input, expected }) => {
+    const lexer = new Lexer(input);
+    const parser = new Parser(lexer);
+    const program = parser.parseProgram();
+    const evaluator = new Evaluator();
+    const evaluated = evaluator.evaluate(program);
+
+    expect(evaluated).toBe(expected);
+  });
+});

--- a/src/evaluator/index.ts
+++ b/src/evaluator/index.ts
@@ -1,0 +1,46 @@
+import type { Program, Node, PrefixExpression } from "../parser";
+
+// TODO: fix any return type to specific ones (by implement value system)
+export default class Evaluator {
+  private evaluateProgram(node: Program): any {
+    let evaluated;
+
+    for (const statement of node.statements) {
+      evaluated = this.evaluate(statement);
+    }
+
+    return evaluated;
+  }
+
+  private evaluatePrefixExpression(prefix: string, operand: number): any {
+    if (prefix === "+") {
+      return operand;
+    }
+    if (prefix === "-") {
+      return -operand;
+    }
+
+    throw new Error(`bad prefix ${prefix}`);
+  }
+
+  evaluate(node: Node): any {
+    if (node.type === "program") {
+      return this.evaluateProgram(node);
+    }
+    if (node.type === "expression statement") {
+      return this.evaluate(node.expression);
+    }
+    if (node.type === "number node") {
+      return node.value;
+    }
+    if (node.type === "prefix expression") {
+      const subExpression = this.evaluate(node.expression);
+      if (typeof subExpression !== "number") {
+        throw new Error(`expected sub expression type number, but received ${typeof subExpression}`);
+      }
+
+      return this.evaluatePrefixExpression(node.prefix, subExpression);
+    }
+    throw new Error(`not supported node type '${node.type}'`);
+  }
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -135,3 +135,5 @@ export default class Parser {
     return program;
   }
 }
+
+export type * from "./syntax-tree";

--- a/src/virtual-machine/index.test.ts
+++ b/src/virtual-machine/index.test.ts
@@ -1,3 +1,0 @@
-import VirtualMachine from "./";
-
-it.todo("");

--- a/src/virtual-machine/index.ts
+++ b/src/virtual-machine/index.ts
@@ -1,5 +1,0 @@
-export default class VirtualMachine {
-  execute(_code: any) { // stub
-    return "standard output";
-  }
-}


### PR DESCRIPTION
features
- add simple tree-walking evaluator
- evaluate number expression (such as `5`, `-5`, and `--5`)

(minor) changes
- export syntax tree node types from parser module

mics.
- remove unused module directories