### PR TITLE
add interface for bundled file

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import execute from "./";
+import { execute } from "./";
 
 it("execute -5", () => {
   expect(execute("-5")).toBe("-5");

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import Lexer from "./lexer";
 import Parser from "./parser";
 import Evaluator from "./evaluator";
 
-const execute = (input: string): string => {
+export const execute = (input: string): string => {
   const lexer = new Lexer(input);
   const parser = new Parser(lexer);
   const parsed = parser.parseProgram();
@@ -12,4 +12,3 @@ const execute = (input: string): string => {
 
   return String(evaluated);
 };
-export default execute;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,12 @@ const { resolve } = require("path");
 module.exports = {
   entry: "./dist/index.js",
   output: {
-    filename: "index.bundle.js",
+    filename: "index.js",
     path: resolve("./bundle"),
+    library: {
+      name: "kal",
+      type: "window",
+    },
   },
   mode: "production",
 };


### PR DESCRIPTION
misc.
- named export used instead of default export, to expose `execute()` instead of `default()` for the bundled file.

## Note

How to use the bundled file:
- Load the bundled file with <script> tag in HTML.
- Use `window.kal.execute(input)` for string `input`, in <script> tag, after bundled file loaded.
  - The `kal` property of `window` is created due to the webpack configuration (see `library` field in `webpack.config.js`)
