### PR TITLE
handle types properly

### DIFF
--- a/src/evaluator/index.ts
+++ b/src/evaluator/index.ts
@@ -1,4 +1,4 @@
-import type { Program, Node, PrefixExpression } from "../parser";
+import type { Program, Node } from "../parser";
 
 // TODO: fix any return type to specific ones (by implement value system)
 export default class Evaluator {

--- a/src/lexer/index.test.ts
+++ b/src/lexer/index.test.ts
@@ -1,16 +1,31 @@
 import Lexer from "./";
-import * as Token from "./token";
-import type * as TokenType from "./token";
+import {
+  operator,
+  identifier,
+  numberLiteral,
+  groupDelimiter,
+  illegal,
+  end,
+} from "./token";
+import type {
+  TokenType,
+  Operator,
+  Identifier,
+  NumberLiteral,
+  GroupDelimiter,
+  Illegal,
+  End,
+} from "./token";
 
 describe("getToken()", () => {
   describe("single token", () => {
     describe("operators", () => {
-      const cases: { input: string, expected: TokenType.Operator }[] = [
-        { input: "+", expected: Token.operator("+") },
-        { input: "-", expected: Token.operator("-") },
-        { input: "*", expected: Token.operator("*") },
-        { input: "/", expected: Token.operator("/") },
-        { input: "=", expected: Token.operator("=") },
+      const cases: { input: string, expected: Operator }[] = [
+        { input: "+", expected: operator("+") },
+        { input: "-", expected: operator("-") },
+        { input: "*", expected: operator("*") },
+        { input: "/", expected: operator("/") },
+        { input: "=", expected: operator("=") },
       ];
 
       it.each(cases)("get operator token '$input'", ({ input, expected }) => {
@@ -23,13 +38,13 @@ describe("getToken()", () => {
     });
 
     describe("identifiers", () => {
-      const cases: { input: string, expected: TokenType.Identifier }[] = [
-        { input: "foo", expected: Token.identifier("foo") },
-        { input: "이름", expected: Token.identifier("이름") },
-        { input: "foo이름", expected: Token.identifier("foo이름") },
-        { input: "foo123", expected: Token.identifier("foo123") },
-        { input: "이름foo", expected: Token.identifier("이름foo") },
-        { input: "_foo이름", expected: Token.identifier("_foo이름") },
+      const cases: { input: string, expected: Identifier }[] = [
+        { input: "foo", expected: identifier("foo") },
+        { input: "이름", expected: identifier("이름") },
+        { input: "foo이름", expected: identifier("foo이름") },
+        { input: "foo123", expected: identifier("foo123") },
+        { input: "이름foo", expected: identifier("이름foo") },
+        { input: "_foo이름", expected: identifier("_foo이름") },
       ];
 
       it.each(cases)("get identifier token '$input'", ({ input, expected }) => {
@@ -42,9 +57,9 @@ describe("getToken()", () => {
     });
 
     describe("literals", () => {
-      const cases: { input: string, expected: TokenType.NumberLiteral }[] = [
-        { input: "0", expected: Token.numberLiteral("0") },
-        { input: "123", expected: Token.numberLiteral("123") },
+      const cases: { input: string, expected: NumberLiteral }[] = [
+        { input: "0", expected: numberLiteral("0") },
+        { input: "123", expected: numberLiteral("123") },
       ];
 
       it.each(cases)("get literal token '$input'", ({ input, expected }) => {
@@ -57,9 +72,9 @@ describe("getToken()", () => {
     });
 
     describe("group delimiters", () => {
-      const cases: { input: "(" | ")", expected: TokenType.GroupDelimiter }[] = [
-        { input: "(", expected: Token.groupDelimiter("(") },
-        { input: ")", expected: Token.groupDelimiter(")") },
+      const cases: { input: "(" | ")", expected: GroupDelimiter }[] = [
+        { input: "(", expected: groupDelimiter("(") },
+        { input: ")", expected: groupDelimiter(")") },
       ];
 
       it.each(cases)("get group delimiter token '$input'", ({ input, expected }) => {
@@ -72,8 +87,8 @@ describe("getToken()", () => {
     });
 
     describe("illegal", () => {
-      const cases: { input: string, expected: TokenType.Illegal }[] = [
-        { input: "$", expected: Token.illegal("$") },
+      const cases: { input: string, expected: Illegal }[] = [
+        { input: "$", expected: illegal("$") },
       ];
 
       it.each(cases)("get illegal token '$input'", ({ input, expected }) => {
@@ -86,8 +101,8 @@ describe("getToken()", () => {
     });
 
     describe("end", () => {
-      const cases: { input: string, expected: TokenType.End }[] = [
-        { input: "", expected: Token.end },
+      const cases: { input: string, expected: End }[] = [
+        { input: "", expected: end },
       ];
 
       it.each(cases)("get end token '$input'", ({ input, expected }) => {
@@ -101,29 +116,29 @@ describe("getToken()", () => {
   });
 
   describe("multiple tokens", () => {
-    const cases: { input: string, expectedTokens: TokenType.TokenType[] }[] = [
+    const cases: { input: string, expectedTokens: TokenType[] }[] = [
       {
         input: "12 + 34 * 5 / 67 - 89",
         expectedTokens: [
-          Token.numberLiteral("12"),
-          Token.operator("+"),
-          Token.numberLiteral("34"),
-          Token.operator("*"),
-          Token.numberLiteral("5"),
-          Token.operator("/"),
-          Token.numberLiteral("67"),
-          Token.operator("-"),
-          Token.numberLiteral("89"),
-          Token.end,
+          numberLiteral("12"),
+          operator("+"),
+          numberLiteral("34"),
+          operator("*"),
+          numberLiteral("5"),
+          operator("/"),
+          numberLiteral("67"),
+          operator("-"),
+          numberLiteral("89"),
+          end,
         ]
       },
       {
         input: "_이름 = foo123",
         expectedTokens: [
-          Token.identifier("_이름"),
-          Token.operator("="),
-          Token.identifier("foo123"),
-          Token.end,
+          identifier("_이름"),
+          operator("="),
+          identifier("foo123"),
+          end,
         ]
       },
     ];
@@ -141,7 +156,7 @@ describe("getToken()", () => {
   describe("no token", () => {
     it("get only end token", () => {
       const input = "  \r\r\n\n\t\t";
-      const expected = Token.end;
+      const expected = end;
 
       const lexer = new Lexer(input);
 

--- a/src/lexer/token/index.test.ts
+++ b/src/lexer/token/index.test.ts
@@ -1,57 +1,67 @@
-import * as Token from "./";
-import type * as TokenType from "./";
+import {
+  operator,
+  identifier,
+  numberLiteral,
+  groupDelimiter,
+} from "./";
+import type {
+  Operator,
+  Identifier,
+  NumberLiteral,
+  GroupDelimiter,
+} from "./";
 
 describe("operator", () => {
-  const cases: { input: TokenType.Operator["value"], expected: TokenType.Operator }[] = [
-    { input: "+", expected: Token.operator("+") },
-    { input: "-", expected: Token.operator("-") },
-    { input: "*", expected: Token.operator("*") },
-    { input: "/", expected: Token.operator("/") },
-    { input: "=", expected: Token.operator("=") },
+  const cases: { input: Operator["value"], expected: Operator }[] = [
+    { input: "+", expected: operator("+") },
+    { input: "-", expected: operator("-") },
+    { input: "*", expected: operator("*") },
+    { input: "/", expected: operator("/") },
+    { input: "=", expected: operator("=") },
   ];
 
   it.each(cases)("make operator token for '$input'", ({ input, expected }) => {
-    const token = Token.operator(input);
+    const token = operator(input);
 
     expect(token).toEqual(expected);
   });
 });
 
 describe("identifier", () => {
-  const cases: { input: TokenType.Identifier["value"], expected: TokenType.Identifier }[] = [
-    { input: "foo", expected: Token.identifier("foo") },
-    { input: "이름", expected: Token.identifier("이름") },
-    { input: "_foo이름123", expected: Token.identifier("_foo이름123") },
+  const cases: { input: Identifier["value"], expected: Identifier }[] = [
+    { input: "foo", expected: identifier("foo") },
+    { input: "이름", expected: identifier("이름") },
+    { input: "_foo이름123", expected: identifier("_foo이름123") },
   ];
 
   it.each(cases)("make identifier token for '$input'", ({ input, expected }) => {
-    const token = Token.identifier(input);
+    const token = identifier(input);
 
     expect(token).toEqual(expected);
   });
 });
 
 describe("number literal", () => {
-  const cases: { input: TokenType.NumberLiteral["value"], expected: TokenType.NumberLiteral }[] = [
-    { input: "0", expected: Token.numberLiteral("0") },
-    { input: "123", expected: Token.numberLiteral("123") },
+  const cases: { input: NumberLiteral["value"], expected: NumberLiteral }[] = [
+    { input: "0", expected: numberLiteral("0") },
+    { input: "123", expected: numberLiteral("123") },
   ];
 
   it.each(cases)("make number literal token for '$input'", ({ input, expected }) => {
-    const token = Token.numberLiteral(input);
+    const token = numberLiteral(input);
 
     expect(token).toEqual(expected);
   });
 });
 
 describe("group delimiter", () => {
-  const cases: { input: TokenType.GroupDelimiter["value"], expected: TokenType.GroupDelimiter }[] = [
-    { input: "(", expected: Token.groupDelimiter("(") },
-    { input: ")", expected: Token.groupDelimiter(")") },
+  const cases: { input: GroupDelimiter["value"], expected: GroupDelimiter }[] = [
+    { input: "(", expected: groupDelimiter("(") },
+    { input: ")", expected: groupDelimiter(")") },
   ];
 
   it.each(cases)("make group delimiter token for '$input'", ({ input, expected }) => {
-    const token = Token.groupDelimiter(input);
+    const token = groupDelimiter(input);
 
     expect(token).toEqual(expected);
   });

--- a/src/lexer/token/index.ts
+++ b/src/lexer/token/index.ts
@@ -1,4 +1,10 @@
-export type TokenType = Operator | Identifier | NumberLiteral | GroupDelimiter | Illegal | End;
+export type TokenType =
+  Operator |
+  Identifier |
+  NumberLiteral |
+  GroupDelimiter |
+  Illegal |
+  End;
 
 export interface Operator {
   type: "operator";

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -14,7 +14,6 @@ import type {
   ExpressionStatement,
   Expression,
   Identifier,
-  PrefixExpression,
 } from "./syntax-tree";
 import Lexer from "../lexer";
 import TokenReader from "./token-reader";

--- a/src/parser/syntax-tree/expression/index.ts
+++ b/src/parser/syntax-tree/expression/index.ts
@@ -1,4 +1,9 @@
-export type Expression = Identifier | NumberNode | PrefixExpression | InfixExpression | Assignment;
+export type Expression =
+  Identifier |
+  NumberNode |
+  PrefixExpression |
+  InfixExpression |
+  Assignment;
 
 export interface Identifier {
   type: "identifier";

--- a/src/parser/syntax-tree/group/index.ts
+++ b/src/parser/syntax-tree/group/index.ts
@@ -1,10 +1,10 @@
-import type * as Statement from "../statement";
+import type { Statement } from "../statement";
 
 export type Group = Program;
 
 export interface Program {
   type: "program";
-  statements: Statement.Statement[];
+  statements: Statement[];
 }
 
 export const makeProgram = (statements: Program["statements"] = []): Program => ({

--- a/src/parser/syntax-tree/statement/index.ts
+++ b/src/parser/syntax-tree/statement/index.ts
@@ -1,11 +1,11 @@
-import type * as Expression from "../expression";
+import type { Expression } from "../expression";
 
 export type Statement = ExpressionStatement;
 
 /** A wrapper type to treat a single expression as a statement. */
 export interface ExpressionStatement {
   type: "expression statement";
-  expression: Expression.Expression;
+  expression: Expression;
 }
 
 export const makeExpressionStatement = (expression: ExpressionStatement["expression"]): ExpressionStatement => ({


### PR DESCRIPTION
minor changes
- remove unused types
- import types explicitly rather than using namespace import
  - why: note that typescript does not restrict using types from namespace import (not type import), so prefer explicit type import