### PR TITLE
support more types for literals

### DIFF
--- a/src/evaluator/index.test.ts
+++ b/src/evaluator/index.test.ts
@@ -19,6 +19,7 @@ describe("evaluate()", () => {
       { input: "100+25*4", expected: 200 },
       { input: "참", expected: true },
       { input: "거짓", expected: false },
+      { input: "'foo bar'", expected: "foo bar" },
 
       /* test case for left associativity */
       { input: "100-25-4", expected: 71 },

--- a/src/evaluator/index.test.ts
+++ b/src/evaluator/index.test.ts
@@ -17,6 +17,8 @@ describe("evaluate()", () => {
       { input: "100+25+4", expected: 129 },
       { input: "100+25-4", expected: 121 },
       { input: "100+25*4", expected: 200 },
+      { input: "참", expected: true },
+      { input: "거짓", expected: false },
 
       /* test case for left associativity */
       { input: "100-25-4", expected: 71 },

--- a/src/evaluator/index.test.ts
+++ b/src/evaluator/index.test.ts
@@ -27,6 +27,10 @@ describe("evaluate()", () => {
       { input: "12-(34-56)", expected: 34 },
       { input: "12*(12/6)", expected: 24 },
       { input: "12+((30+4)-3*(12/(56-50)))", expected: 40 },
+
+      /* test case for floating point numbers */
+      { input: "0.75 + 1.25", expected: 2 },
+      { input: "2.5 / 0.5", expected: 5 },
     ];
 
     it.each(cases)("evaluate $input", ({ input, expected }) => {

--- a/src/evaluator/index.ts
+++ b/src/evaluator/index.ts
@@ -54,6 +54,9 @@ export default class Evaluator {
     if (node.type === "boolean node") {
       return node.value;
     }
+    if (node.type === "string node") {
+      return node.value;
+    }
     if (node.type === "infix expression") {
       const left = this.evaluate(node.left, env);
       const right = this.evaluate(node.right, env);

--- a/src/evaluator/index.ts
+++ b/src/evaluator/index.ts
@@ -51,6 +51,9 @@ export default class Evaluator {
     if (node.type === "number node") {
       return node.value;
     }
+    if (node.type === "boolean node") {
+      return node.value;
+    }
     if (node.type === "infix expression") {
       const left = this.evaluate(node.left, env);
       const right = this.evaluate(node.right, env);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,6 +12,10 @@ it("execute 4-(3-(2-1))", () => {
   expect(execute("4-(3-(2-1))")).toBe("2");
 });
 
+it("execute 2.5/0.5", () => {
+  expect(execute("2.5/0.5")).toBe("5");
+});
+
 it("execute assignment", () => {
   expect(execute("변수1 = 4  변수2 = 9  (변수2 - 변수1) * 변수1")).toBe("20");
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,6 +16,10 @@ it("execute 2.5/0.5", () => {
   expect(execute("2.5/0.5")).toBe("5");
 });
 
+it("execute 참", () => {
+  expect(execute("참")).toBe("true"); // TODO(?): display as "참"
+});
+
 it("execute assignment", () => {
   expect(execute("변수1 = 4  변수2 = 9  (변수2 - 변수1) * 변수1")).toBe("20");
 });

--- a/src/lexer/index.test.ts
+++ b/src/lexer/index.test.ts
@@ -56,6 +56,9 @@ describe("getToken()", () => {
       const cases: { input: string, expected: NumberLiteral }[] = [
         { input: "0", expected: numberLiteral("0") },
         { input: "123", expected: numberLiteral("123") },
+        { input: "12.75", expected: numberLiteral("12.75") },
+        { input: "0.875", expected: numberLiteral("0.875") },
+        { input: "2.00", expected: numberLiteral("2.00") },
       ];
 
       it.each(cases)("get literal token '$input'", testLexing);

--- a/src/lexer/index.test.ts
+++ b/src/lexer/index.test.ts
@@ -4,6 +4,7 @@ import {
   identifier,
   numberLiteral,
   booleanLiteral,
+  stringLiteral,
   groupDelimiter,
   illegal,
   end,
@@ -14,6 +15,7 @@ import type {
   Identifier,
   NumberLiteral,
   BooleanLiteral,
+  StringLiteral,
   GroupDelimiter,
   Illegal,
   End,
@@ -75,6 +77,18 @@ describe("getToken()", () => {
       it.each(cases)("get boolean literal token '$input'", testLexing);
     });
 
+    describe("string literals", () => {
+      const cases: { input: string, expected: StringLiteral }[] = [
+        { input: "'foo bar'", expected: stringLiteral("foo bar") },
+        { input: "'123'", expected: stringLiteral("123") },
+        { input: "'!@#$'", expected: stringLiteral("!@#$") },
+        { input: "'   '", expected: stringLiteral("   ") },
+        { input: "'참'", expected: stringLiteral("참") },
+      ];
+
+      it.each(cases)("get string literal token '$input'", testLexing);
+    });
+
     describe("group delimiters", () => {
       const cases: { input: string, expected: GroupDelimiter }[] = [
         { input: "(", expected: groupDelimiter("(") },
@@ -87,6 +101,7 @@ describe("getToken()", () => {
     describe("illegal", () => {
       const cases: { input: string, expected: Illegal }[] = [
         { input: "$", expected: illegal("$") },
+        { input: "'foo", expected: illegal("'foo") },
       ];
 
       it.each(cases)("get illegal token '$input'", testLexing);
@@ -124,6 +139,14 @@ describe("getToken()", () => {
           identifier("_이름"),
           operator("="),
           identifier("foo123"),
+          end,
+        ]
+      },
+      {
+        input: "'foo' 'bar'",
+        expectedTokens: [
+          stringLiteral("foo"),
+          stringLiteral("bar"),
           end,
         ]
       },

--- a/src/lexer/index.test.ts
+++ b/src/lexer/index.test.ts
@@ -3,6 +3,7 @@ import {
   operator,
   identifier,
   numberLiteral,
+  booleanLiteral,
   groupDelimiter,
   illegal,
   end,
@@ -12,6 +13,7 @@ import type {
   Operator,
   Identifier,
   NumberLiteral,
+  BooleanLiteral,
   GroupDelimiter,
   Illegal,
   End,
@@ -52,7 +54,7 @@ describe("getToken()", () => {
       it.each(cases)("get identifier token '$input'", testLexing);
     });
 
-    describe("literals", () => {
+    describe("number literals", () => {
       const cases: { input: string, expected: NumberLiteral }[] = [
         { input: "0", expected: numberLiteral("0") },
         { input: "123", expected: numberLiteral("123") },
@@ -61,7 +63,16 @@ describe("getToken()", () => {
         { input: "2.00", expected: numberLiteral("2.00") },
       ];
 
-      it.each(cases)("get literal token '$input'", testLexing);
+      it.each(cases)("get number literal token '$input'", testLexing);
+    });
+
+    describe("boolean literals", () => {
+      const cases: { input: string, expected: BooleanLiteral }[] = [
+        { input: "참", expected: booleanLiteral("참") },
+        { input: "거짓", expected: booleanLiteral("거짓") },
+      ];
+
+      it.each(cases)("get boolean literal token '$input'", testLexing);
     });
 
     describe("group delimiters", () => {

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -10,8 +10,35 @@ export default class Lexer {
   }
 
   private readNumber(): string {
+    const wholeNumberPart = this.readWholeNumberPart();
+    const decimalPart = this.readDecimalPart();
+
+    const number = wholeNumberPart + decimalPart;
+
+    return number;
+  }
+
+  private readWholeNumberPart(): string {
     // read digits
     const read = [];
+    while (Util.isDigit(this.buffer.peek())) {
+      read.push(this.buffer.pop());
+    }
+
+    return read.join("");
+  }
+
+  private readDecimalPart(): string {
+    // early return if not decimal point
+    const maybeDecimalPoint = this.buffer.peek();
+    if (maybeDecimalPoint !== ".") {
+      return "";
+    }
+
+    const read = [maybeDecimalPoint];
+    this.buffer.pop(); // eat the decimal point
+
+    // read digits after decimal point
     while (Util.isDigit(this.buffer.peek())) {
       read.push(this.buffer.pop());
     }

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -46,6 +46,27 @@ export default class Lexer {
     return read.join("");
   }
 
+  /** return [string-literal, true] if ok; otherwise [string-read-so-far, false] */
+  private readStringLiteral(): [string, boolean] {
+    const read: string[] = [];
+
+    // read string until string closing symbol (')
+    while (true) {
+      const char = this.buffer.pop();
+
+      // return illegal token if end before reading string
+      if (char === "\0") {
+        return [read.join(""), false];
+      }
+
+      if (char === "'") {
+        return [read.join(""), true];
+      }
+
+      read.push(char);
+    }
+  }
+
   private readIdentifier(): string {
     // read letters and digits
     const read = [];
@@ -84,6 +105,13 @@ export default class Lexer {
         this.buffer.pop(); // discard current character
 
         return Token.groupDelimiter(char);
+      case "'":
+        {
+          this.buffer.pop(); // discard current character
+
+          const [str, ok] = this.readStringLiteral();
+          return ok ? Token.stringLiteral(str) : Token.illegal("'" + str);
+        }
       case "\0":
         return Token.end;
       default:

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -94,9 +94,16 @@ export default class Lexer {
         }
 
         if (Util.isLetter(char)) {
-          const identifier = this.readIdentifier();
+          // match keyword first before matching identifier
+          // since identifier is a string of letters not matched with keywords
 
-          return Token.identifier(identifier);
+          const read = this.readIdentifier();
+
+          if (read === "참" || read === "거짓") {
+            return Token.booleanLiteral(read);
+          }
+
+          return Token.identifier(read);
         }
 
         this.buffer.pop(); // discard current character

--- a/src/lexer/token/index.test.ts
+++ b/src/lexer/token/index.test.ts
@@ -3,6 +3,7 @@ import {
   identifier,
   numberLiteral,
   booleanLiteral,
+  stringLiteral,
   groupDelimiter,
 } from "./";
 import type {
@@ -10,6 +11,7 @@ import type {
   Identifier,
   NumberLiteral,
   BooleanLiteral,
+  StringLiteral,
   GroupDelimiter,
 } from "./";
 
@@ -64,6 +66,21 @@ describe("boolean literal", () => {
 
   it.each(cases)("make boolean literal token for '$input'", ({ input, expected }) => {
     const token = booleanLiteral(input);
+
+    expect(token).toEqual(expected);
+  });
+});
+
+describe("string literal", () => {
+  const cases: { input: StringLiteral["value"], expected: StringLiteral }[] = [
+    { input: "foo bar", expected: stringLiteral("foo bar") },
+    { input: "  ", expected: stringLiteral("  ") },
+    { input: "123", expected: stringLiteral("123") },
+    { input: "참", expected: stringLiteral("참") },
+  ];
+
+  it.each(cases)("make string literal token for '$input'", ({ input, expected }) => {
+    const token = stringLiteral(input);
 
     expect(token).toEqual(expected);
   });

--- a/src/lexer/token/index.test.ts
+++ b/src/lexer/token/index.test.ts
@@ -2,12 +2,14 @@ import {
   operator,
   identifier,
   numberLiteral,
+  booleanLiteral,
   groupDelimiter,
 } from "./";
 import type {
   Operator,
   Identifier,
   NumberLiteral,
+  BooleanLiteral,
   GroupDelimiter,
 } from "./";
 
@@ -49,6 +51,19 @@ describe("number literal", () => {
 
   it.each(cases)("make number literal token for '$input'", ({ input, expected }) => {
     const token = numberLiteral(input);
+
+    expect(token).toEqual(expected);
+  });
+});
+
+describe("boolean literal", () => {
+  const cases: { input: BooleanLiteral["value"], expected: BooleanLiteral }[] = [
+    { input: "참", expected: booleanLiteral("참") },
+    { input: "거짓", expected: booleanLiteral("거짓") },
+  ];
+
+  it.each(cases)("make boolean literal token for '$input'", ({ input, expected }) => {
+    const token = booleanLiteral(input);
 
     expect(token).toEqual(expected);
   });

--- a/src/lexer/token/index.ts
+++ b/src/lexer/token/index.ts
@@ -2,6 +2,7 @@ export type TokenType =
   Operator |
   Identifier |
   NumberLiteral |
+  BooleanLiteral |
   GroupDelimiter |
   Illegal |
   End;
@@ -19,6 +20,11 @@ export interface Identifier {
 export interface NumberLiteral {
   type: "number literal";
   value: string;
+}
+
+export interface BooleanLiteral {
+  type: "boolean literal";
+  value: "참" | "거짓";
 }
 
 export interface GroupDelimiter {
@@ -48,6 +54,11 @@ export const identifier = (value: Identifier["value"]): Identifier => ({
 
 export const numberLiteral = (value: NumberLiteral["value"]): NumberLiteral => ({
   type: "number literal",
+  value,
+});
+
+export const booleanLiteral = (value: BooleanLiteral["value"]): BooleanLiteral => ({
+  type: "boolean literal",
   value,
 });
 

--- a/src/lexer/token/index.ts
+++ b/src/lexer/token/index.ts
@@ -3,6 +3,7 @@ export type TokenType =
   Identifier |
   NumberLiteral |
   BooleanLiteral |
+  StringLiteral |
   GroupDelimiter |
   Illegal |
   End;
@@ -25,6 +26,11 @@ export interface NumberLiteral {
 export interface BooleanLiteral {
   type: "boolean literal";
   value: "참" | "거짓";
+}
+
+export interface StringLiteral {
+  type: "string literal";
+  value: string;
 }
 
 export interface GroupDelimiter {
@@ -59,6 +65,11 @@ export const numberLiteral = (value: NumberLiteral["value"]): NumberLiteral => (
 
 export const booleanLiteral = (value: BooleanLiteral["value"]): BooleanLiteral => ({
   type: "boolean literal",
+  value,
+});
+
+export const stringLiteral = (value: StringLiteral["value"]): StringLiteral => ({
+  type: "string literal",
   value,
 });
 

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -506,6 +506,32 @@ describe("parseProgram()", () => {
           ],
         },
       },
+      {
+        name: "true boolean literal",
+        input: "참",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: { type: "boolean node", value: true },
+            },
+          ],
+        },
+      },
+      {
+        name: "false boolean literal",
+        input: "거짓",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: { type: "boolean node", value: false },
+            },
+          ],
+        },
+      },
     ];
 
     it.each(cases)("parse $name", testParsing);

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -532,6 +532,19 @@ describe("parseProgram()", () => {
           ],
         },
       },
+      {
+        name: "string literal",
+        input: "'foo bar'",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: { type: "string node", value: "foo bar" },
+            },
+          ],
+        },
+      },
     ];
 
     it.each(cases)("parse $name", testParsing);

--- a/src/parser/index.test.ts
+++ b/src/parser/index.test.ts
@@ -488,6 +488,24 @@ describe("parseProgram()", () => {
           ],
         },
       },
+      {
+        name: "arithmetic expression with floating point numbers",
+        input: "0.75 + 1.25",
+        expected: {
+          type: "program",
+          statements: [
+            {
+              type: "expression statement",
+              expression: {
+                type: "infix expression",
+                infix: "+",
+                left: { type: "number node", value: 0.75 },
+                right: { type: "number node", value: 1.25 },
+              },
+            },
+          ],
+        },
+      },
     ];
 
     it.each(cases)("parse $name", testParsing);

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -3,6 +3,7 @@ import {
   makeIdentifier,
   makeAssignment,
   makeNumberNode,
+  makeBooleanNode,
   makeExpressionStatement,
   makePrefixExpression,
   makeInfixExpression,
@@ -11,6 +12,7 @@ import type {
   Program,
   Statement,
   NumberNode,
+  BooleanNode,
   ExpressionStatement,
   Expression,
   Identifier,
@@ -99,6 +101,10 @@ export default class Parser {
       const numberNode = this.parseNumberLiteral(token.value);
       return numberNode;
     }
+    if (token.type === "boolean literal") {
+      const booleanNode = this.parseBooleanLiteral(token.value);
+      return booleanNode;
+    }
     if (token.type === "identifier") {
       const identifier = makeIdentifier(token.value);
       return identifier;
@@ -169,6 +175,12 @@ export default class Parser {
     }
 
     return makeNumberNode(parsedNumber);
+  }
+
+  private parseBooleanLiteral(literal: "참" | "거짓"): BooleanNode {
+    const parsedValue = literal === "참";
+
+    return makeBooleanNode(parsedValue);
   }
 }
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -4,6 +4,7 @@ import {
   makeAssignment,
   makeNumberNode,
   makeBooleanNode,
+  makeStringNode,
   makeExpressionStatement,
   makePrefixExpression,
   makeInfixExpression,
@@ -13,6 +14,7 @@ import type {
   Statement,
   NumberNode,
   BooleanNode,
+  StringNode,
   ExpressionStatement,
   Expression,
   Identifier,
@@ -105,6 +107,10 @@ export default class Parser {
       const booleanNode = this.parseBooleanLiteral(token.value);
       return booleanNode;
     }
+    if (token.type === "string literal") {
+      const stringNode = this.parseStringLiteral(token.value);
+      return stringNode;
+    }
     if (token.type === "identifier") {
       const identifier = makeIdentifier(token.value);
       return identifier;
@@ -130,7 +136,7 @@ export default class Parser {
       return groupedExpression;
     }
 
-    throw new Error(`bad token type ${token.type} for prefix expression`);
+    throw new Error(`bad token type ${token.type} (${token.value}) for prefix expression`);
   }
 
   private parseInfixExpression(left: Expression): Expression | null {
@@ -181,6 +187,10 @@ export default class Parser {
     const parsedValue = literal === "참";
 
     return makeBooleanNode(parsedValue);
+  }
+
+  private parseStringLiteral(literal: string): StringNode {
+    return makeStringNode(literal);
   }
 }
 

--- a/src/parser/syntax-tree/expression/index.ts
+++ b/src/parser/syntax-tree/expression/index.ts
@@ -2,6 +2,7 @@ export type Expression =
   Identifier |
   NumberNode |
   BooleanNode |
+  StringNode |
   PrefixExpression |
   InfixExpression |
   Assignment;
@@ -19,6 +20,11 @@ export interface NumberNode {
 export interface BooleanNode {
   type: "boolean node";
   value: boolean;
+}
+
+export interface StringNode {
+  type: "string node";
+  value: string;
 }
 
 export interface PrefixExpression {
@@ -52,6 +58,11 @@ export const makeNumberNode = (value: NumberNode["value"]): NumberNode => ({
 
 export const makeBooleanNode = (value: BooleanNode["value"]): BooleanNode => ({
   type: "boolean node",
+  value,
+});
+
+export const makeStringNode = (value: StringNode["value"]): StringNode => ({
+  type: "string node",
   value,
 });
 

--- a/src/parser/syntax-tree/expression/index.ts
+++ b/src/parser/syntax-tree/expression/index.ts
@@ -1,6 +1,7 @@
 export type Expression =
   Identifier |
   NumberNode |
+  BooleanNode |
   PrefixExpression |
   InfixExpression |
   Assignment;
@@ -13,6 +14,11 @@ export interface Identifier {
 export interface NumberNode {
   type: "number node";
   value: number;
+}
+
+export interface BooleanNode {
+  type: "boolean node";
+  value: boolean;
 }
 
 export interface PrefixExpression {
@@ -41,6 +47,11 @@ export const makeIdentifier = (value: Identifier["value"]): Identifier => ({
 
 export const makeNumberNode = (value: NumberNode["value"]): NumberNode => ({
   type: "number node",
+  value,
+});
+
+export const makeBooleanNode = (value: BooleanNode["value"]): BooleanNode => ({
+  type: "boolean node",
   value,
 });
 


### PR DESCRIPTION
feat.
- support floating point literal (e.g., `123.45`)
- support boolean literal (e.g., `참`, `거짓`)
- support string literal (e.g., `'foo bar'`)