### PR TITLE
add evaluated type system

### DIFF
--- a/src/evaluator/environment/index.test.ts
+++ b/src/evaluator/environment/index.test.ts
@@ -1,49 +1,52 @@
+import type { Evaluated } from "../evaluated";
 import Environment from "./";
 
 describe("set()", () => {
   it("set name and value", () => {
     const env = new Environment();
+    const varName = "foo";
+    const varValue = {} as Evaluated;
 
-    expect(() => env.set("foo", 42)).not.toThrow();
+    expect(() => env.set(varName, varValue)).not.toThrow();
   });
 });
 
 describe("get()", () => {
   it("get value after setting the value", () => {
     const env = new Environment();
+    const varName = "foo";
+    const varValue = {} as Evaluated;
 
-    env.set("foo", 42);
-    const value = env.get("foo");
+    env.set(varName, varValue);
 
-    expect(value).toBe(42);
+    expect(env.get(varName)).toBe(varValue);
   });
 
   it("get null if not found", () => {
     const env = new Environment();
+    const varNameNotSet = "foo";
 
-    const value = env.get("foo");
-
-    expect(value).toBe(null);
+    expect(env.get(varNameNotSet)).toBe(null);
   });
 });
 
 describe("linked environment", () => {
   it("set super environment and get via sub environment", () => {
+    const varNameInSuper = "foo";
+    const varValueInSuper = {} as Evaluated;
+
     const superEnv = new Environment();
-    superEnv.set("foo", 42);
+    superEnv.set(varNameInSuper, varValueInSuper);
     const subEnv = new Environment(superEnv);
 
-    const value = subEnv.get("foo");
-
-    expect(value).toBe(42);
+    expect(subEnv.get(varNameInSuper)).toBe(varValueInSuper);
   });
 
   it("get null if not found even in super environment", () => {
     const superEnv = new Environment();
     const subEnv = new Environment(superEnv);
 
-    const value = subEnv.get("foo");
-
-    expect(value).toBe(null);
+    const varNameSetNowhere = "foo";
+    expect(subEnv.get(varNameSetNowhere)).toBe(null);
   });
 });

--- a/src/evaluator/environment/index.ts
+++ b/src/evaluator/environment/index.ts
@@ -1,6 +1,8 @@
+import type { Evaluated } from "../evaluated";
+
 export interface EnvironmentType {
-  get: (name: string) => unknown;
-  set: (name: string, value: any) => unknown;
+  get: (name: string) => Evaluated | null;
+  set: (name: string, value: Evaluated) => void;
 }
 
 export default class Environment implements EnvironmentType {
@@ -12,7 +14,7 @@ export default class Environment implements EnvironmentType {
     this.table = new Map<string, any>;
   }
 
-  get(name: string): unknown {
+  get(name: string): Evaluated | null {
     // return if found in current environment
     const fetched = this.table.get(name);
     if (fetched !== undefined) {
@@ -26,9 +28,7 @@ export default class Environment implements EnvironmentType {
     return this.superEnvironment.get(name);
   }
 
-  set(name: string, value: any): unknown {
+  set(name: string, value: Evaluated): void {
     this.table.set(name, value);
-
-    return value;
   }
 }

--- a/src/evaluator/evaluated/index.test.ts
+++ b/src/evaluator/evaluated/index.test.ts
@@ -1,0 +1,82 @@
+import {
+  makeEvaluatedNumber,
+  makeEvaluatedString,
+  makeEvaluatedBoolean,
+  makeEvaluatedFunction,
+  makeEvaluatedEmpty,
+} from "./";
+import type {
+  FunctionExpression
+} from "../../parser/syntax-tree";
+import type Environment from "../environment";
+
+describe("makeEvaluatedNumber()", () => {
+  it("make number value", () => {
+    const evaluated = makeEvaluatedNumber(42);
+
+    expect(evaluated.type).toBe("number");
+    expect(evaluated.value).toBe(42);
+    expect(evaluated.representation).toBe("42");
+  });
+});
+
+describe("makeEvaluatedString()", () => {
+  it("make nonempty string value", () => {
+    const evaluated = makeEvaluatedString("foo bar");
+
+    expect(evaluated.type).toBe("string");
+    expect(evaluated.value).toBe("foo bar");
+    expect(evaluated.representation).toBe("'foo bar'");
+  });
+
+  it("make empty string value", () => {
+    const evaluated = makeEvaluatedString("");
+
+    expect(evaluated.type).toBe("string");
+    expect(evaluated.value).toBe("");
+    expect(evaluated.representation).toBe("''");
+  });
+});
+
+describe("makeEvaluatedBoolean()", () => {
+  it("make true boolean value", () => {
+    const evaluated = makeEvaluatedBoolean(true);
+
+    expect(evaluated.type).toBe("boolean");
+    expect(evaluated.value).toBe(true);
+    expect(evaluated.representation).toBe("참");
+  });
+
+  it("make false boolean value", () => {
+    const evaluated = makeEvaluatedBoolean(false);
+
+    expect(evaluated.type).toBe("boolean");
+    expect(evaluated.value).toBe(false);
+    expect(evaluated.representation).toBe("거짓");
+  });
+});
+
+describe("makeEvaluatedFunction()", () => {
+  it("make function value", () => {
+    const parametersMock = [] as FunctionExpression["parameter"];
+    const bodyMock = {} as FunctionExpression["body"];
+    const environmentMock = {} as Environment;
+
+    const evaluated = makeEvaluatedFunction(parametersMock, bodyMock, environmentMock);
+
+    expect(evaluated.type).toBe("function");
+    expect(evaluated.parameters).toBe(parametersMock);
+    expect(evaluated.body).toBe(bodyMock);
+    expect(evaluated.environment).toBe(environmentMock);
+    expect(evaluated.representation).toBe("(함수)");
+  });
+});
+
+describe("makeEvaluatedEmpty()", () => {
+  it("make empty value", () => {
+    const evaluated = makeEvaluatedEmpty();
+
+    expect(evaluated.type).toBe("empty");
+    expect(evaluated.representation).toBe("(비어있음)");
+  });
+});

--- a/src/evaluator/evaluated/index.ts
+++ b/src/evaluator/evaluated/index.ts
@@ -35,6 +35,15 @@ export interface EvaluatedEmpty extends EvaluatedBase {
   readonly type: "empty";
 }
 
+export type Evaluated =
+  EvaluatedPrimitive |
+  EvaluatedFunction |
+  EvaluatedEmpty;
+export type EvaluatedPrimitive =
+  EvaluatedNumber |
+  EvaluatedString |
+  EvaluatedBoolean;
+
 export type MakeEvaluatedNumber = (value: number) => EvaluatedNumber;
 export const makeEvaluatedNumber: MakeEvaluatedNumber = value => ({
   type: "number",

--- a/src/evaluator/evaluated/index.ts
+++ b/src/evaluator/evaluated/index.ts
@@ -1,0 +1,86 @@
+import type {
+  FunctionExpression,
+} from "../../parser/syntax-tree";
+import type Environment from "../environment";
+
+interface EvaluatedBase {
+  readonly type: string;
+  readonly representation: string;
+}
+
+export interface EvaluatedNumber extends EvaluatedBase {
+  readonly type: "number";
+  readonly value: number;
+}
+
+export interface EvaluatedString extends EvaluatedBase {
+  readonly type: "string";
+  readonly value: string;
+}
+
+export interface EvaluatedBoolean extends EvaluatedBase {
+  readonly type: "boolean";
+  readonly value: boolean;
+}
+
+export interface EvaluatedFunction extends EvaluatedBase {
+  readonly type: "function";
+  readonly parameters: FunctionExpression["parameter"];
+  readonly body: FunctionExpression["body"];
+  readonly environment: Environment;
+}
+
+// 'empty' represents the result of running statement (e.g., branching) in REPL
+export interface EvaluatedEmpty extends EvaluatedBase {
+  readonly type: "empty";
+}
+
+export type MakeEvaluatedNumber = (value: number) => EvaluatedNumber;
+export const makeEvaluatedNumber: MakeEvaluatedNumber = value => ({
+  type: "number",
+  value,
+  get representation() {
+    return `${value}`;
+  },
+});
+
+export type MakeEvaluatedString = (value: string) => EvaluatedString;
+export const makeEvaluatedString: MakeEvaluatedString = value => ({
+  type: "string",
+  value,
+  get representation() {
+    return `'${value}'`;
+  },
+});
+
+export type MakeEvaluatedBoolean = (value: boolean) => EvaluatedBoolean;
+export const makeEvaluatedBoolean: MakeEvaluatedBoolean = value => ({
+  type: "boolean",
+  value,
+  get representation() {
+    return value ? "참" : "거짓";
+  },
+});
+
+export type MakeEvaluatedFunction = (
+  parameters: FunctionExpression["parameter"],
+  body: FunctionExpression["body"],
+  environment: Environment
+) => EvaluatedFunction;
+export const makeEvaluatedFunction: MakeEvaluatedFunction = (parameters, body, environment) => ({
+  type: "function",
+  parameters,
+  body,
+  environment,
+  get representation() {
+    return "(함수)";
+  },
+});
+
+export type MakeEvaluatedEmpty = () => EvaluatedEmpty;
+export const makeEvaluatedEmpty: MakeEvaluatedEmpty = () => ({
+  type: "empty",
+  get representation() {
+    return "(비어있음)";
+  },
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,7 @@
 import { execute } from "./";
 
+it.todo("");
+
 it("execute -5", () => {
   expect(execute("-5")).toBe("-5");
 });
@@ -17,23 +19,23 @@ it("execute 2.5/0.5", () => {
 });
 
 it("execute 참", () => {
-  expect(execute("참")).toBe("true"); // TODO(?): display as "참"
+  expect(execute("참")).toBe("참");
 });
 
 it("execute 1 == 2", () => {
-  expect(execute("1 == 2")).toBe("false");
+  expect(execute("1 == 2")).toBe("거짓");
 });
 
 it("execute 2 > 1 == 참", () => {
-  expect(execute("2 > 1 == 참")).toBe("true");
+  expect(execute("2 > 1 == 참")).toBe("참");
 });
 
 it("execute 1 != 1 == 거짓", () => { // note that comparison is left associative
-  expect(execute("1 != 1 == 거짓")).toBe("true");
+  expect(execute("1 != 1 == 거짓")).toBe("참");
 });
 
 it("execute 거짓 == (1 < 1+1)", () => {
-  expect(execute("거짓 == (1 < 1+1)")).toBe("false");
+  expect(execute("거짓 == (1 < 1+1)")).toBe("거짓");
 });
 
 it("execute 만약 1 == 1 { 2 } 아니면 { 3 }", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,5 @@
 import { execute } from "./";
 
-it.todo("");
-
 it("execute -5", () => {
   expect(execute("-5")).toBe("-5");
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,5 @@ export const execute = (input: string): string => {
   const environment = new Environment();
   const evaluated = evaluator.evaluate(parsed, environment);
 
-  return String(evaluated);
+  return String(evaluated.representation);
 };


### PR DESCRIPTION
internals
- `Evaluated` type has:
  - `representation` field to show the value to users
  - `value` field to store the value evaluated from the corresponding syntax node
- the evaluator yields `Evaluated` type value
- the executor shows the `representation` field of the `Evaluated` type value

(minor) refactoring
- factor out testing function
- divide large testing chunks into more specific groups