### PR TITLE
add evaluator with position context

### DIFF
--- a/src/evaluator/environment/v2.test.ts
+++ b/src/evaluator/environment/v2.test.ts
@@ -1,0 +1,52 @@
+import type { Value } from "../value";
+import Environment from "./v2";
+
+describe("set()", () => {
+  it("set name and value", () => {
+    const env = new Environment();
+    const varName = "foo";
+    const varValue = {} as Value;
+
+    expect(() => env.set(varName, varValue)).not.toThrow();
+  });
+});
+
+describe("get()", () => {
+  it("get value after setting the value", () => {
+    const env = new Environment();
+    const varName = "foo";
+    const varValue = {} as Value;
+
+    env.set(varName, varValue);
+
+    expect(env.get(varName)).toBe(varValue);
+  });
+
+  it("get null if not found", () => {
+    const env = new Environment();
+    const varNameNotSet = "foo";
+
+    expect(env.get(varNameNotSet)).toBe(null);
+  });
+});
+
+describe("linked environment", () => {
+  it("set super environment and get via sub environment", () => {
+    const varNameInSuper = "foo";
+    const varValueInSuper = {} as Value;
+
+    const superEnv = new Environment();
+    superEnv.set(varNameInSuper, varValueInSuper);
+    const subEnv = new Environment(superEnv);
+
+    expect(subEnv.get(varNameInSuper)).toBe(varValueInSuper);
+  });
+
+  it("get null if not found even in super environment", () => {
+    const superEnv = new Environment();
+    const subEnv = new Environment(superEnv);
+
+    const varNameSetNowhere = "foo";
+    expect(subEnv.get(varNameSetNowhere)).toBe(null);
+  });
+});

--- a/src/evaluator/environment/v2.ts
+++ b/src/evaluator/environment/v2.ts
@@ -1,0 +1,34 @@
+import type { Value } from "../value";
+
+export interface EnvironmentType {
+  get: (name: string) => Value | null;
+  set: (name: string, value: Value) => void;
+}
+
+export default class Environment implements EnvironmentType {
+  private readonly superEnvironment: Environment | null;
+  private readonly table: Map<string, any>;
+
+  constructor(superEnvironment: Environment | null = null) {
+    this.superEnvironment = superEnvironment;
+    this.table = new Map<string, any>;
+  }
+
+  get(name: string): Value | null {
+    // return if found in current environment
+    const fetched = this.table.get(name);
+    if (fetched !== undefined) {
+      return fetched;
+    }
+
+    // return value in super environment
+    if (this.superEnvironment === null) {
+      return null;
+    }
+    return this.superEnvironment.get(name);
+  }
+
+  set(name: string, value: Value): void {
+    this.table.set(name, value);
+  }
+}

--- a/src/evaluator/index.ts
+++ b/src/evaluator/index.ts
@@ -29,6 +29,7 @@ import type {
 } from "./evaluated";
 import Environment from "./environment";
 
+/** @deprecated */
 export default class Evaluator {
   evaluate(node: Program, env: Environment): Evaluated {
     return this.evaluateProgram(node, env);

--- a/src/evaluator/v2.test.ts
+++ b/src/evaluator/v2.test.ts
@@ -1,0 +1,359 @@
+import Lexer from "../lexer";
+import Parser from "../parser/v2";
+import Evaluator from "./v2";
+import Environment from "./environment/v2";
+
+const evaluateInput = (input: string) => {
+  const lexer = new Lexer(input);
+  const parser = new Parser(lexer);
+  const parsed = parser.parseSource();
+
+  const evaluator = new Evaluator();
+  const env = new Environment();
+  const evaluated = evaluator.evaluate(parsed, env);
+  return evaluated;
+};
+
+const testEvaluatingPrimitive = ({ input, expected }: { input: string, expected: any }): void => {
+  const evaluated = evaluateInput(input) as any;
+
+  expect(evaluated.value).toBe(expected);
+};
+
+const testEvaluatingEmpty= ({ input }: { input: string }): void => {
+  const evaluated = evaluateInput(input) as any;
+
+  expect(evaluated.value).toBe(null);
+};
+
+const testEvaluatingFunction = ({ input, expectedParamsLength }: { input: string, expectedParamsLength: number }): void => {
+  const evaluated = evaluateInput(input) as any;
+
+  expect(evaluated).toHaveProperty("parameters");
+  expect(evaluated.parameters.length).toBe(expectedParamsLength);
+  expect(evaluated).toHaveProperty("body");
+  expect(evaluated).toHaveProperty("environment");
+};
+
+describe("evaluate()", () => {
+  describe("single numbers", () => {
+    const cases = [
+      { input: "5", expected: 5 },
+      { input: "-5", expected: -5 },
+      { input: "--5", expected: 5 },
+      { input: "+5", expected: 5 },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("simple arithmetic expressions", () => {
+    const cases = [
+      { input: "100+25", expected: 125 },
+      { input: "100-25", expected: 75 },
+      { input: "100*25", expected: 2500 },
+      { input: "100/25", expected: 4 },
+      { input: "100+25+4", expected: 129 },
+      { input: "100+25-4", expected: 121 },
+      { input: "100+25*4", expected: 200 },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("left associativity of arithmetic operation", () => {
+    const cases = [
+      { input: "100-25-4", expected: 71 },
+      { input: "100/25/4", expected: 1 },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("grouped arithmetic expressions", () => {
+    const cases = [
+      { input: "100-(25-4)", expected: 79 },
+      { input: "12-(34-56)", expected: 34 },
+      { input: "12*(12/6)", expected: 24 },
+      { input: "12+((30+4)-3*(12/(56-50)))", expected: 40 },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("arithmetic expressions with floating point number", () => {
+    const cases = [
+      { input: "0.75 + 1.25", expected: 2 },
+      { input: "2.5 / 0.5", expected: 5 },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("single boolean", () => {
+    const cases = [
+      { input: "참", expected: true },
+      { input: "거짓", expected: false },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("logical not expressions", () => {
+    const cases = [
+      { input: "!참", expected: false },
+      { input: "!거짓", expected: true },
+      { input: "!!참", expected: true },
+      { input: "!!거짓", expected: false },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("single string", () => {
+    const cases = [
+      { input: "''", expected: "" },
+      { input: "'foo bar'", expected: "foo bar" },
+      { input: "'한글 단어'", expected: "한글 단어" },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("boolean comparison", () => {
+    const cases = [
+      { input: "참 == 참", expected: true },
+      { input: "거짓 == 참", expected: false },
+      { input: "참 == 거짓", expected: false },
+      { input: "거짓 == 거짓", expected: true },
+      { input: "참 != 참", expected: false },
+      { input: "거짓 != 참", expected: true },
+      { input: "참 != 거짓", expected: true },
+      { input: "거짓 != 거짓", expected: false },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("number comparison", () => {
+    const cases = [
+      { input: "2 > 1", expected: true },
+      { input: "1 > 1", expected: false },
+      { input: "1 > 2", expected: false },
+      { input: "2 >= 1", expected: true },
+      { input: "1 >= 1", expected: true },
+      { input: "1 >= 2", expected: false },
+      { input: "2 < 1", expected: false },
+      { input: "1 < 1", expected: false },
+      { input: "1 < 2", expected: true },
+      { input: "2 <= 1", expected: false },
+      { input: "1 <= 1", expected: true },
+      { input: "1 <= 2", expected: true },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("string comparison", () => {
+    const cases = [
+      { input: "'사과' == '사과'", expected: true },
+      { input: "'사과' != '사과'", expected: false },
+      { input: "'사과' == '바나나'", expected: false },
+      { input: "'사과' != '바나나'", expected: true },
+      { input: "'B' > 'A'", expected: true },
+      { input: "'A' > 'A'", expected: false },
+      { input: "'A' > 'B'", expected: false },
+      { input: "'B' >= 'A'", expected: true },
+      { input: "'A' >= 'A'", expected: true },
+      { input: "'A' >= 'B'", expected: false },
+      { input: "'B' < 'A'", expected: false },
+      { input: "'A' < 'A'", expected: false },
+      { input: "'A' < 'B'", expected: true },
+      { input: "'B' <= 'A'", expected: false },
+      { input: "'A' <= 'A'", expected: true },
+      { input: "'A' <= 'B'", expected: true },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("logical not operation to boolean expression", () => {
+    const cases = [
+      { input: "!(1 == 1)", expected: false },
+      { input: "!!(1 == 1)", expected: true },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("branch statements yielding something", () => {
+    const cases = [
+      {
+        name: "simple if statement with boolean literal predicate",
+        input: "만약 참 { 3 }",
+        expected: 3
+      },
+      {
+        name: "simple if statement with boolean expression predicate",
+        input: "만약 1 != 2 { 4 }",
+        expected: 4
+      },
+      {
+        name: "simple if statement with variable comparison predicate",
+        input: "사과 = 3  바나나 = 4  만약 사과 < 바나나 { 5 }",
+        expected: 5
+      },
+      {
+        name: "simple if-else statement with true boolean literal predicate",
+        input: "만약 참 { 6 } 아니면 { 7 }",
+        expected: 6
+      },
+      {
+        name: "simple if-else statement with false boolean literal predicate",
+        input: "만약 거짓 { 6 } 아니면 { 7 }",
+        expected: 7
+      },
+      {
+        name: "simple if-else statement with boolean expression predicate",
+        input: "만약 1 == 2 { 34 } 아니면 { 56 }",
+        expected: 56
+      },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("branch statements yielding nothing", () => {
+    const cases = [
+      {
+        name: "simple if statement with boolean literal predicate",
+        input: "만약 거짓 { 3 }",
+      },
+      {
+        name: "simple if statement with boolean expression predicate",
+        input: "만약 1 == 2 { 4 }",
+      },
+      {
+        name: "simple if statement with variable comparison predicate",
+        input: "사과 = 3  바나나 = 4  만약 사과 > 바나나 { 5 }",
+      },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingEmpty);
+  });
+
+  describe("nested branch statements yielding something", () => {
+    const cases = [
+      {
+        name: "nested if statements",
+        input: "만약 참 { 만약 참 { 만약 참 { 1 } } }",
+        expected: 1,
+      },
+      {
+        name: "nested if-else statements",
+        input: "만약 거짓 { 0 } 아니면 { 만약 참 { 만약 거짓 { 1 } 아니면 { 2 } } 아니면 { 3 } }",
+        expected: 2,
+      },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingPrimitive);
+  });
+
+  describe("nested branch statements yielding nothing", () => {
+    const cases = [
+      {
+        name: "nested if statements",
+        input: "만약 참 { 만약 참 { 만약 거짓 { 1 } } }",
+      },
+      {
+        name: "nested if and if-else statements",
+        input: "만약 거짓 { 만약 참 { 만약 거짓 { 0 } 아니면 { 1 } } 아니면 { 2 } }",
+      },
+    ];
+
+    it.each(cases)("evaluate $input", testEvaluatingEmpty);
+  });
+
+  describe("variable statements", () => {
+    const cases = [
+      {
+        name: "integer variable with number literal",
+        input: "foo = 42  foo",
+        expected: 42
+      },
+      {
+        name: "integer variable with arithmetic expression",
+        input: "foo = 42 * (8 / 4) + (1 - (2 - 1))  foo",
+        expected: 84
+      },
+      {
+        name: "two integer variables with number literal",
+        input: "foo = 42  bar = foo + 1  bar",
+        expected: 43
+      },
+      {
+        name: "arithmetic expression with variables",
+        input: "foo = 42  bar = 43  baz = 44  qux = (bar * (baz - foo))",
+        expected: 86
+      },
+      {
+        name: "Korean integer variable with number literal",
+        input: "변수 = 42  변수",
+        expected: 42
+      },
+    ];
+
+    it.each(cases)("evaluate $name", testEvaluatingPrimitive);
+  });
+
+  describe("function expressions", () => {
+    const cases = [
+      {
+        name: "simple function expression",
+        input: "함수 () { 1 }",
+        expectedParamsLength: 0,
+      },
+      {
+        name: "simple function expression",
+        input: "함수 (사과, 바나나, 포도) { 1 }",
+        expectedParamsLength: 3,
+      },
+    ];
+
+    it.each(cases)("evaluate $name", testEvaluatingFunction);
+  });
+
+  describe("call expressions", () => {
+    const cases = [
+      {
+        name: "function call with function literal",
+        input: "함수(바나나) { 결과 바나나 + 1 }(42)",
+        expected: 43,
+      },
+      {
+        name: "function call with identifier",
+        input: "더하기 = 함수(숫자1, 숫자2) { 결과 숫자1 + 숫자2 }  더하기(3, 4)",
+        expected: 7,
+      },
+    ];
+
+    it.each(cases)("evaluate $name", testEvaluatingPrimitive);
+  });
+
+  describe("complex statements with function and calls", () => {
+    const cases = [
+      {
+        name: "make and call function containing branch statement",
+        input: "과일 = 함수(색깔) { 만약 (색깔 == '빨강') { 결과 '사과' } 아니면 { '포도' } }  과일('빨강')",
+        expected: "사과",
+      },
+      {
+        name: "make and call closure",
+        input: "더하기 = 함수(숫자1) { 결과 함수(숫자2) { 결과 숫자1+숫자2 } }  하나더하기 = 더하기(1)  하나더하기(4)",
+        expected: 5,
+      },
+    ];
+
+    it.each(cases)("evaluate $name", testEvaluatingPrimitive);
+  });
+});

--- a/src/evaluator/v2.ts
+++ b/src/evaluator/v2.ts
@@ -1,0 +1,350 @@
+import type * as Node from "../parser/v2";
+import type * as Value from "./value";
+import * as value from "./value";
+import Environment from "./environment/v2";
+import type { Range } from "../util/position";
+
+class EvalError extends Error {
+  public range: Range;
+
+  constructor(range: Range) {
+    super();
+    this.range = range;
+  }
+}
+
+class TopLevelReturnError extends EvalError {};
+class BadPredicateError extends EvalError {};
+class BadAssignmentLeftError extends EvalError {};
+class BadPrefixExpressionError extends EvalError {};
+class BadInfixExpressionError extends EvalError {};
+class BadIdentifierError extends EvalError {};
+
+type ComparisonOperator = "==" | "!=" | ">" | "<" | ">=" | "<=";
+
+export default class Evaluator {
+  evaluate(node: Node.ProgramNode, env: Environment): Value.Value {
+    return this.evaluateProgram(node, env);
+  }
+
+  private evaluateProgram(node: Node.ProgramNode, env: Environment): Value.Value {
+    const { statements } = node;
+
+    let lastEvaluated: Value.Value | null = null;
+    for (let i = 0; i < statements.length; ++i) {
+      const evaluated = this.evaluateStatement(statements[i], env);
+
+      if (evaluated.type === "return") {
+        throw new TopLevelReturnError(node.range);
+      }
+
+      lastEvaluated = evaluated;
+    }
+
+    return lastEvaluated ?? this.createEmptyValue(node.range);
+  }
+
+  private evaluateStatement(node: Node.StatementNode, env: Environment): Value.Value | Value.ReturnValue {
+    if (node.type === "branch") {
+      return this.evaluateBranchStatement(node, env);
+    }
+    if (node.type === "expression statement") {
+      return this.evaluateExpressionStatement(node, env);
+    }
+    if (node.type === "return") {
+      const val = this.evaluateExpression(node.expression, env);
+      return value.createReturnValue(val);
+    }
+
+    const nothing: never = node;
+    return nothing;
+  }
+
+  private evaluateBranchStatement(node: Node.BranchNode, env: Environment): Value.Value | Value.ReturnValue {
+    const pred = this.evaluateExpression(node.predicate, env);
+    if (pred.type !== "boolean") {
+      throw new BadPredicateError(node.range);
+    }
+
+    if (pred.value) {
+      return this.evaluateBlock(node.consequence, env);
+    }
+
+    if (node.alternative === undefined) {
+      return this.createEmptyValue(node.range);
+    }
+
+    return this.evaluateBlock(node.alternative, env);
+  }
+
+  private evaluateBlock(node: Node.BlockNode, env: Environment): Value.Value | Value.ReturnValue {
+    let lastEvaluated: Value.Value | null = null;
+
+    for (let i = 0; i < node.statements.length; ++i) {
+      const evaluated = this.evaluateStatement(node.statements[i], env);
+
+      if (evaluated.type === "return") {
+        return evaluated;
+      }
+
+      lastEvaluated = evaluated;
+    }
+
+    return lastEvaluated ?? this.createEmptyValue(node.range);
+  }
+
+  private evaluateExpressionStatement(node: Node.ExpressionStatementNode, env: Environment): Value.Value {
+    return this.evaluateExpression(node.expression, env);
+  }
+
+  private evaluateExpression(node: Node.ExpressionNode, env: Environment): Value.Value {
+    if (node.type === "number") {
+      return this.createNumberValue(node.value, node.range);
+    }
+    if (node.type === "boolean") {
+      return this.createBooleanValue(node.value, node.range);
+    }
+    if (node.type === "string") {
+      return this.createStringValue(node.value, node.range);
+    }
+    if (node.type === "prefix") {
+      return this.evaluatePrefixExpression(node, env);
+    }
+    if (node.type === "infix") {
+      return this.evaluateInfixExpression(node, env);
+    }
+    if (node.type === "assignment") {
+      return this.evaluateAssignment(node, env);
+    }
+    if (node.type === "identifier") {
+      return this.evaluateIdentifier(node, env);
+    }
+    if (node.type === "function") {
+      return this.evaluateFunctionExpression(node, env);
+    }
+    if (node.type === "call") {
+      return this.evaluateCall(node, env);
+    }
+
+    const _never: never = node;
+    return _never;
+  }
+
+  private evaluatePrefixExpression(node: Node.PrefixNode, env: Environment): Value.Value {
+    const right = this.evaluateExpression(node.right, env);
+
+    if ((node.prefix === "+" || node.prefix === "-") && right.type == "number") {
+      return this.evaluatePrefixNumberExpression(node.prefix, right);
+    }
+    if (node.prefix === "!" && right.type === "boolean") {
+      return this.evaluatePrefixBooleanExpression(node.prefix, right);
+    }
+
+    throw new BadPrefixExpressionError(node.range);
+  }
+
+  private evaluateInfixExpression(node: Node.InfixNode, env: Environment): Value.Value {
+    const left = this.evaluateExpression(node.left, env);
+    const right = this.evaluateExpression(node.right, env);
+
+    if (left.type === "number" && right.type === "number" && this.isArithmeticInfixOperator(node.infix)) {
+      const value = this.getArithmeticInfixOperationValue(left.value, right.value, node.infix);
+      return this.createNumberValue(value, node.range);
+    }
+
+    if (left.type === "number" && right.type === "number" && this.isComparisonInfixOperator(node.infix)) {
+      const value = this.getNumericComparisonInfixOperationValue(left.value, right.value, node.infix);
+      return this.createBooleanValue(value, node.range);
+    }
+
+    if (left.type === "boolean" && right.type === "boolean" && this.isComparisonInfixOperator(node.infix)) {
+      const value = this.getBooleanComparisonInfixOperationValue(left.value, right.value, node.infix);
+      return this.createBooleanValue(value, node.range);
+    }
+
+    if (left.type === "string" && right.type === "string" && this.isComparisonInfixOperator(node.infix)) {
+      const value = this.getStringComparisonInfixOperationValue(left.value, right.value, node.infix);
+      return this.createBooleanValue(value, node.range);
+    }
+
+    throw new BadInfixExpressionError(node.range);
+  }
+
+  private evaluateIdentifier(node: Node.IdentifierNode, env: Environment): Value.Value {
+    const varName = node.value;
+    const value = env.get(varName);
+
+    if (value === null) {
+      throw new BadIdentifierError(node.range);
+    }
+
+    return value;
+  }
+
+  private evaluateAssignment(node: Node.AssignmentNode, env: Environment): Value.Value {
+    if (node.left.type !== "identifier") {
+      throw new BadAssignmentLeftError(node.range);
+    }
+
+    const varName = node.left.value;
+    const varValue = this.evaluateExpression(node.right, env);
+
+    env.set(varName, varValue);
+
+    return varValue; // evaluated value of assignment is the evaluated value of variable
+  }
+
+  private evaluateFunctionExpression(node: Node.FunctionNode, env: Environment): Value.Value {
+    return this.createFunctionValue(node.parameters, node.body, env, node.range);
+  }
+
+  private evaluateCall(node: Node.CallNode, env: Environment): Value.Value {
+    const func = this.evaluateExpression(node.func, env);
+    if (func.type !== "function") {
+      throw new Error(`expected function but received ${func.type}`);
+    }
+
+    const callArguments = this.evaluateCallArguments(node.args, env);
+
+    const value = this.evaluateFunctionCall(func, callArguments);
+    return value;
+  }
+
+  private evaluateCallArguments(args: Node.ExpressionNode[], env: Environment): Value.Value[] {
+    return args.map(arg => this.evaluateExpression(arg, env));
+  }
+
+  private evaluateFunctionCall(func: Value.FunctionValue, callArguments: Value.Value[]): Value.Value {
+    const env = this.createExtendedEnvironment(func.environment, func.parameters, callArguments);
+
+    const blockValue = this.evaluateBlock(func.body, env);
+    if (blockValue.type !== "return") {
+      // TODO: better error with range
+      throw new Error(`expected return value in function but it didn't`);
+    }
+
+    const returnValue = blockValue.value;
+    return returnValue;
+  }
+
+  private getBooleanComparisonInfixOperationValue(left: boolean, right: boolean, operator: ComparisonOperator): boolean {
+    return this.getComparisonInfixOperationValue<boolean>(left, right, operator);
+  }
+
+  private getNumericComparisonInfixOperationValue(left: number, right: number, operator: ComparisonOperator): boolean {
+    return this.getComparisonInfixOperationValue<number>(left, right, operator);
+  }
+
+  private getStringComparisonInfixOperationValue(left: string, right: string, operator: ComparisonOperator): boolean {
+    return this.getComparisonInfixOperationValue<string>(left, right, operator);
+  }
+
+  private getComparisonInfixOperationValue<T>(left: T, right: T, operator: ComparisonOperator): boolean {
+    if (operator === "==") {
+      return left === right;
+    }
+    if (operator === "!=") {
+      return left !== right;
+    }
+    if (operator === ">") {
+      return left > right;
+    }
+    if (operator === "<") {
+      return left < right;
+    }
+    if (operator === ">=") {
+      return left >= right;
+    }
+    if (operator === "<=") {
+      return left <= right;
+    }
+
+    const _never: never = operator;
+    return _never;
+  }
+
+  private getArithmeticInfixOperationValue(left: number, right: number, operator: "+" | "-" | "*" | "/"): number {
+    if (operator === "+") {
+      return left + right;
+    }
+    if (operator === "-") {
+      return left - right;
+    }
+    if (operator === "*") {
+      return left * right;
+    }
+    if (operator === "/") {
+      return left / right;
+    }
+
+    const _never: never = operator;
+    return _never;
+  }
+
+  private evaluatePrefixNumberExpression(prefix: "+" | "-", node: Node.NumberNode): Value.NumberValue {
+    if (prefix === "+") {
+      return this.createNumberValue(node.value, node.range);
+    }
+    if (prefix === "-") {
+      return this.createNumberValue(-node.value, node.range);
+    }
+
+    const _never: never = prefix;
+    return _never;
+  }
+
+  private evaluatePrefixBooleanExpression(prefix: "!", node: Node.BooleanNode): Value.BooleanValue {
+    if (prefix === "!") {
+      return this.createBooleanValue(!node.value, node.range);
+    }
+
+    const _never: never = prefix;
+    return _never;
+  }
+
+  private createExtendedEnvironment(oldEnv: Environment, identifiers: Node.IdentifierNode[], values: Value.Value[]): Environment {
+    const newEnv = new Environment(oldEnv);
+
+    for (let i = 0; i < identifiers.length; ++i) {
+      const name = identifiers[i].value;
+      const value = values[i];
+      newEnv.set(name, value);
+    }
+
+    return newEnv;
+  }
+
+  // create value functions: wrappers for consistent representation
+
+  private createNumberValue(val: number, range: Range): Value.NumberValue {
+    return value.createNumberValue({ value: val }, String(value), range);
+  }
+
+  private createBooleanValue(val: boolean, range: Range): Value.BooleanValue {
+    return value.createBooleanValue({ value: val }, value ? "참" : "거짓", range);
+  }
+
+  private createStringValue(val: string, range: Range): Value.StringValue {
+    return value.createStringValue({ value: val }, val, range);
+  }
+
+  private createEmptyValue(range: Range): Value.EmptyValue {
+    return value.createEmptyValue({ value: null }, "(없음)", range);
+  }
+
+  private createFunctionValue(parameters: Node.FunctionNode["parameters"], body: Node.FunctionNode["body"], environment: Environment, range: Range): Value.FunctionValue {
+    return value.createFunctionValue({ parameters, body, environment }, "(함수)", range);
+  }
+
+  // util predicate functions
+
+  private isArithmeticInfixOperator(operator: string): operator is "+" | "-" | "*" | "/" {
+    return ["+", "-", "*", "/"].some(infix => infix === operator);
+  }
+
+  private isComparisonInfixOperator(operator: string): operator is ComparisonOperator {
+    return ["==", "!=", ">", "<", ">=", "<="].some(infix => infix === operator);
+  }
+}
+
+export { default as Environment } from "./environment";

--- a/src/evaluator/v2.ts
+++ b/src/evaluator/v2.ts
@@ -4,21 +4,23 @@ import * as value from "./value";
 import Environment from "./environment/v2";
 import type { Range } from "../util/position";
 
-class EvalError extends Error {
+export class EvalError extends Error {
   public range: Range;
+  public received?: string;
 
-  constructor(range: Range) {
+  constructor(range: Range, received?: string) {
     super();
     this.range = range;
+    this.received = received;
   }
 }
 
-class TopLevelReturnError extends EvalError {};
-class BadPredicateError extends EvalError {};
-class BadAssignmentLeftError extends EvalError {};
-class BadPrefixExpressionError extends EvalError {};
-class BadInfixExpressionError extends EvalError {};
-class BadIdentifierError extends EvalError {};
+export class TopLevelReturnError extends EvalError {};
+export class BadPredicateError extends EvalError {};
+export class BadAssignmentLeftError extends EvalError {};
+export class BadPrefixExpressionError extends EvalError {};
+export class BadInfixExpressionError extends EvalError {};
+export class BadIdentifierError extends EvalError {};
 
 type ComparisonOperator = "==" | "!=" | ">" | "<" | ">=" | "<=";
 
@@ -63,7 +65,7 @@ export default class Evaluator {
   private evaluateBranchStatement(node: Node.BranchNode, env: Environment): Value.Value | Value.ReturnValue {
     const pred = this.evaluateExpression(node.predicate, env);
     if (pred.type !== "boolean") {
-      throw new BadPredicateError(node.range);
+      throw new BadPredicateError(pred.range, pred.representation);
     }
 
     if (pred.value) {
@@ -175,7 +177,7 @@ export default class Evaluator {
     const value = env.get(varName);
 
     if (value === null) {
-      throw new BadIdentifierError(node.range);
+      throw new BadIdentifierError(node.range, varName);
     }
 
     return value;

--- a/src/evaluator/v2.ts
+++ b/src/evaluator/v2.ts
@@ -317,11 +317,11 @@ export default class Evaluator {
   // create value functions: wrappers for consistent representation
 
   private createNumberValue(val: number, range: Range): Value.NumberValue {
-    return value.createNumberValue({ value: val }, String(value), range);
+    return value.createNumberValue({ value: val }, String(val), range);
   }
 
   private createBooleanValue(val: boolean, range: Range): Value.BooleanValue {
-    return value.createBooleanValue({ value: val }, value ? "참" : "거짓", range);
+    return value.createBooleanValue({ value: val }, val ? "참" : "거짓", range);
   }
 
   private createStringValue(val: string, range: Range): Value.StringValue {
@@ -347,4 +347,4 @@ export default class Evaluator {
   }
 }
 
-export { default as Environment } from "./environment";
+export { default as Environment } from "./environment/v2";

--- a/src/evaluator/value/index.ts
+++ b/src/evaluator/value/index.ts
@@ -1,0 +1,61 @@
+import { copyRange, type Range } from "../../util/position";
+import type { FunctionNode } from "../../parser/v2";
+import Environment from "../environment/v2";
+
+export interface ValueBase<T extends string = string> {
+  readonly type: T,
+  readonly representation: string,
+  readonly range: Range,
+}
+
+export type Value = PrimitiveValue
+  | EmptyValue
+
+export type PrimitiveValue = NumberValue
+  | StringValue
+  | BooleanValue
+  | FunctionValue
+
+export interface NumberValue extends ValueBase<"number"> {
+  readonly value: number,
+}
+export interface StringValue extends ValueBase<"string"> {
+  readonly value: string,
+}
+export interface BooleanValue extends ValueBase<"boolean"> {
+  readonly value: boolean,
+}
+export interface FunctionValue extends ValueBase<"function"> {
+  readonly parameters: FunctionNode["parameters"],
+  readonly body: FunctionNode["body"],
+  readonly environment: Environment,
+}
+export interface EmptyValue extends ValueBase<"empty"> {
+  readonly value: null,
+}
+
+export interface ReturnValue {
+  readonly type: "return",
+  readonly value: Value,
+}
+
+const createValueCreator = <T extends string, V extends ValueBase<T>>(type: T) => {
+  return (fields: Omit<V, keyof ValueBase<T>>, representation: string, range: Range) => ({
+    type,
+    range: copyRange(range.begin, range.end),
+    representation,
+    ...fields,
+  });
+};
+type CreateValue<T extends string, V extends ValueBase<T>> = (fields: Omit<V, keyof ValueBase<T>>, representation: string, range: Range) => V;
+
+export const createNumberValue: CreateValue<"number", NumberValue> = createValueCreator<"number", NumberValue>("number");
+export const createBooleanValue: CreateValue<"boolean", BooleanValue> = createValueCreator<"boolean", BooleanValue>("boolean");
+export const createStringValue: CreateValue<"string", StringValue> = createValueCreator<"string", StringValue>("string");
+export const createEmptyValue: CreateValue<"empty", EmptyValue> = createValueCreator<"empty", EmptyValue>("empty");
+export const createFunctionValue: CreateValue<"function", FunctionValue> = createValueCreator<"function", FunctionValue>("function");
+
+export const createReturnValue = (value: Value): ReturnValue => ({
+  type: "return",
+  value,
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,12 +24,12 @@ it("execute 1 == 2", () => {
   expect(execute("1 == 2")).toBe("거짓");
 });
 
-it("execute 2 > 1 == 참", () => {
-  expect(execute("2 > 1 == 참")).toBe("참");
+it("execute 참 == 2 > 1", () => {
+  expect(execute("참 == 2 > 1")).toBe("참");
 });
 
-it("execute 1 != 1 == 거짓", () => { // note that comparison is left associative
-  expect(execute("1 != 1 == 거짓")).toBe("참");
+it("execute 거짓 == 1 != 1", () => { // note that comparison is left associative
+  expect(execute("거짓 == 1 != 1")).toBe("참");
 });
 
 it("execute 거짓 == (1 < 1+1)", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import Lexer from "./lexer";
-import Parser from "./parser";
-import Evaluator, { Environment } from "./evaluator";
+import Parser from "./parser/v2";
+import Evaluator, { Environment } from "./evaluator/v2";
 
 export const execute = (input: string): string => {
   const lexer = new Lexer(input);
   const parser = new Parser(lexer);
-  const parsed = parser.parseProgram();
+  const parsed = parser.parseSource();
 
   const evaluator = new Evaluator();
   const environment = new Environment();

--- a/src/parser/v2.ts
+++ b/src/parser/v2.ts
@@ -96,7 +96,7 @@ export default class Parser {
   }
 
   private parseBranchStatement(): Node.BranchNode {
-    const { range } = this.reader.read();
+    const firstToken = this.reader.read();
     this.reader.advance();
 
     const predicate = this.parseExpression(bindingPowers.lowest);
@@ -104,19 +104,22 @@ export default class Parser {
 
     const maybeElseToken = this.reader.read();
     if (maybeElseToken.type !== "keyword" || maybeElseToken.value !== "아니면") {
+      const range = { begin: firstToken.range.begin, end: consequence.range.end };
       return node.createBranchNode({ predicate, consequence }, range);
     }
     this.reader.advance();
 
     const alternative = this.parseBlock();
+    const range = { begin: firstToken.range.begin, end: alternative.range.end };
     return node.createBranchNode({ predicate, consequence, alternative }, range);
   }
 
   private parseReturnStatement(): Node.ReturnNode {
-    const { range } = this.reader.read();
+    const firstToken = this.reader.read();
     this.reader.advance();
 
     const expression = this.parseExpression(bindingPowers.lowest);
+    const range = { begin: firstToken.range.begin, end: expression.range.end };
     return node.createReturnNode({ expression }, range);
   }
 


### PR DESCRIPTION
internal
- `v2` evaluator: value systems now contain position context
- some errors are handled (e.g., missing identifier, top level return, bad predicate)
